### PR TITLE
Separate a breaking API change by Cargo feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
 script:
   - cargo fmt --all -- --check
   #- cargo clippy --all # TODO: clippy
-  - cargo build --release
+  - cargo build --no-default-features --release
   # - cargo test --release # TODO: figure out why tests hang on CI
-  - cargo build --tests
+  - cargo build --no-default-features --tests
   - cargo doc --no-deps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,11 @@ lazy_static = "1"
 librpm-sys = { version = "0.1", path = "librpm-sys" }
 streaming-iterator = "0.1"
 
+[features]
+librpm-4-14 = []
+
+default = ["librpm-4-14"]
+
 [workspace]
 members = [
     "librpm-sys",

--- a/src/macro_context.rs
+++ b/src/macro_context.rs
@@ -32,6 +32,19 @@ impl MacroContext {
         Ok(())
     }
 
+    #[cfg(feature = "librpm-4-14")]
+    /// Delete a macro from this context.
+    pub fn pop(&self, name: &str) -> Result<(), Error> {
+        let cstr = CString::new(name).unwrap();
+
+        unsafe {
+            librpm_sys::rpmPopMacro(self.0, cstr.as_ptr());
+        }
+
+        Ok(())
+    }
+
+    #[cfg(not(feature = "librpm-4-14"))]
     /// Delete a macro from this context.
     pub fn delete(&self, name: &str) -> Result<(), Error> {
         let cstr = CString::new(name).unwrap();


### PR DESCRIPTION
Different from #7 in that it supports both old and new versions and doesn't fork the codebase by underlying library version.

I.e. I develop on Fedora 31 with recent librpm, and build the final product to CentOS 7 with older one.