### PR TITLE
Redo CI so that it builds and runs natively on Fedora and CentOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,37 @@
 language: rust
-cache: cargo
 os: linux
 sudo: true
+
+env:
+  - DIST=fedora
+  - DIST=centos8
+
+# podman is currently not in Ubuntu
+addons:
+  apt:
+    update: true
+    sources:
+      - sourceline: "ppa:projectatomic/ppa"
+    packages:
+      - podman
+      - slirp4netns
 
 branches:
   only:
     - master
 
+before_install:
+  # podman needs a basic register set up (packaging bug in the ppa)
+  - sudo mkdir -p /etc/containers
+  - echo -e "[registries.search]\nregistries = ['docker.io']" | sudo tee /etc/containers/registries.conf
+  # we need to register travis to allow subuid/gid for the rootless execution
+  - echo "travis:110000:65535" | sudo tee /etc/subuid
+  - echo "travis:110000:65535" | sudo tee /etc/subgid
+
+# rust here is just a no-op, we rely on containers entirely
 rust:
-  - 1.31.0
   - stable
 
-env:
-  global:
-    - RUST_BACKTRACE=1
-    - RUSTFLAGS="-D warnings"
-
-install:
-  - sudo apt-get install rpm librpm-dev
-  - sudo rpm --initdb
-  - rustup component add rustfmt
-  - rustup component add clippy
-
 script:
-  - cargo fmt --all -- --check
-  #- cargo clippy --all # TODO: clippy
-  - cargo build --no-default-features --release
-  # - cargo test --release # TODO: figure out why tests hang on CI
-  - cargo build --no-default-features --tests
-  - cargo doc --no-deps
+  - podman build -t $DIST -f ci/Dockerfile.${DIST} .
+  - podman run $DIST

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,43 +2,12 @@
 #
 # Resulting image is published as rustrpm/ci on Docker Hub
 
-FROM centos:7.4.1708
+FROM centos:8
 
-# Include cargo in the path
-ENV PATH "$PATH:/root/.cargo/bin"
-
-# Install/update RPMs
+# Update container RPMs and install Rust compiler + rust dev tools
 RUN yum update -y && \
-    yum groupinstall -y "Development Tools" && \
-    yum install -y centos-release-scl rpm-devel zlib-devel && \
-    yum install -y --enablerepo=centos-sclo-rh llvm-toolset-7
-
-# Set environment variables to enable llvm-toolset-7 SCL package
-ENV LD_LIBRARY_PATH "/opt/rh/llvm-toolset-7/root/usr/lib64"
-ENV PATH "/opt/rh/llvm-toolset-7/root/usr/bin:/opt/rh/llvm-toolset-7/root/usr/sbin:$PATH"
-ENV PKG_CONFIG_PATH "/opt/rh/llvm-toolset-7/root/usr/lib64/pkgconfig"
-ENV X_SCLS llvm-toolset-7
-
-# Install rustup
-WORKDIR /root
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
-
-# Rust nightly version to install
-ENV RUST_NIGHTLY_VERSION "nightly-2018-06-02"
-
-# Install Rust nightly
-RUN rustup install $RUST_NIGHTLY_VERSION
-
-# Add the Rust sysroot to ld.so.conf
-RUN bash -l -c "echo $(rustc --print sysroot)/lib >> /etc/ld.so.conf"
-RUN ldconfig
-
-# Install rustfmt
-RUN rustup component add rustfmt-preview --toolchain $RUST_NIGHTLY_VERSION
-
-# Install clippy
-ENV CLIPPY_VERSION "0.0.206"
-RUN cargo +$RUST_NIGHTLY_VERSION install clippy --vers $CLIPPY_VERSION
+    yum install -y rust cargo clippy rustfmt clang-devel rpm-devel zlib-devel && \
+    yum clean all
 
 # Configure Rust environment variables
 ENV RUST_BACKTRACE full

--- a/ci/Dockerfile.centos8
+++ b/ci/Dockerfile.centos8
@@ -1,0 +1,8 @@
+FROM centos:8
+
+WORKDIR /usr/src/librpm.rs
+COPY . .
+        
+RUN dnf -y install rpm-devel clang-devel rust cargo clippy rustfmt && dnf -y clean all
+
+CMD ci/ci-checks.sh

--- a/ci/Dockerfile.fedora
+++ b/ci/Dockerfile.fedora
@@ -1,0 +1,8 @@
+FROM registry.fedoraproject.org/fedora:latest
+
+WORKDIR /usr/src/librpm.rs
+COPY . .
+        
+RUN dnf -y install rpm-devel clang-devel rust cargo clippy rustfmt && dnf -y clean all
+
+CMD ci/ci-checks.sh

--- a/ci/ci-checks.sh
+++ b/ci/ci-checks.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+export RUST_BACKTRACE=1
+export RUSTFLAGS="-D warnings"
+
+cargo fmt --all -- --check
+
+cargo build --release
+cargo build --tests
+cargo doc --no-deps
+


### PR DESCRIPTION
This configuration allows us to work around the weaknesses in Travis CI by using Fedora and CentOS containers that provide a native environment to build and test the RPM bindings.

In addition, the `rustrpm/ci` image is updated to CentOS 8 as it massively simplifies the image since the 2018 edition of Rust is supported as part of the Rust compiler shipped in the distribution.
