### PR TITLE
Implement Packge::from_file()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,10 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+* `Package::from_file()` reads an `.rpm` file directly into a `Package`
+* `Package::get()` exposes raw tag data access via `Tag` and `TagData`,
+  both of which are now part of the public API
+
 ### Changed
 
 * Brought the exposed tag constants up to date with RPM 6.0
 * Auto-detect available tag constants at build time for compatibility with older librpm versions
+* `Package` is now a thin wrapper around librpm's refcounted header instead
+  of eagerly copying all tag values into owned `String` fields. Accessors
+  perform tag lookups on demand. `PartialEq` and `Hash` compare by NEVRA.
 
 ### Fixed
 

--- a/librpm-sys/build.rs
+++ b/librpm-sys/build.rs
@@ -47,7 +47,7 @@ fn main() {
         // to uncomment as safe Rust wrappers are added.
         // ----------------------------------------------------------
         // header.h — package header access
-        // .allowlist_function("headerNew")
+        .allowlist_function("headerNew")
         .allowlist_function("headerFree")
         .allowlist_function("headerLink")
         // .allowlist_function("headerExport")
@@ -119,7 +119,8 @@ fn main() {
         // .allowlist_function("rpmfiFree")
         // .allowlist_function("rpmfiNext")
         // rpmio.h — I/O routines
-        // .allowlist_function("Fopen")
+        .allowlist_function("Fopen")
+        .allowlist_function("Fclose")
         // .allowlist_function("Fdopen")
         // .allowlist_function("Fclose")
         // .allowlist_function("Fflush")
@@ -138,7 +139,7 @@ fn main() {
         // .allowlist_function("rpmFreeRpmrc")
         // .allowlist_function("rpmVersionCompare")
         // .allowlist_function("headerCheck")
-        // .allowlist_function("rpmReadPackageFile")
+        .allowlist_function("rpmReadPackageFile")
         // rpmmacro.h — macro system
         .allowlist_function("rpmDefineMacro")
         .allowlist_function("rpmPopMacro")
@@ -226,7 +227,7 @@ fn main() {
         // .allowlist_function("rpmtsProblems")
         // .allowlist_function("rpmtsEmpty")
         // .allowlist_function("rpmtsVSFlags")
-        // .allowlist_function("rpmtsSetVSFlags")
+        .allowlist_function("rpmtsSetVSFlags")
         // .allowlist_function("rpmtsVfyFlags")
         // .allowlist_function("rpmtsSetVfyFlags")
         // .allowlist_function("rpmtsVfyLevel")
@@ -372,6 +373,8 @@ fn main() {
         .allowlist_type("rpmSigTag_e")
         .allowlist_type("rpmTagType_e")
         .allowlist_type("rpmTagClass_e")
+        // rpmtypes.h — return codes
+        .allowlist_type("rpmRC_e")
         // header.h — header access flags
         .allowlist_type("headerGetFlags_e")
         // .allowlist_type("headerPutFlags_e")
@@ -379,7 +382,7 @@ fn main() {
         // .allowlist_type("hMagic")
         // rpmts.h — transaction control flags
         // .allowlist_type("rpmtransFlags_e")
-        // .allowlist_type("rpmVSFlags_e")
+        .allowlist_type("rpmVSFlags_e")
         // .allowlist_type("rpmtxnFlags_e")
         // rpmte.h — transaction element type
         // .allowlist_type("rpmElementType_e")
@@ -424,6 +427,8 @@ fn main() {
             println!("cargo:rpmtag_{}=1", tag.to_lowercase());
         } else if let Some(tag) = name.strip_prefix("rpmSigTag_e_RPMSIGTAG_") {
             println!("cargo:rpmsigtag_{}=1", tag.to_lowercase());
+        } else if let Some(flag) = name.strip_prefix("rpmVSFlags_e_RPMVSF_") {
+            println!("cargo:rpmvsflag_{}=1", flag.to_lowercase());
         }
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -54,7 +54,7 @@ impl Iterator for Iter {
 
     /// Obtain the next header from the iterator.
     fn next(&mut self) -> Option<Package> {
-        self.0.next().map(|h| h.to_package())
+        self.0.next().map(Package::from_header)
     }
 }
 

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -22,8 +22,9 @@
 pub(crate) mod global_state;
 pub(crate) mod header;
 pub(crate) mod iterator;
-pub(crate) mod tag;
-pub(crate) mod td;
+pub mod rc;
+pub mod tag;
+pub mod td;
 pub(crate) mod ts;
 
 pub(crate) use self::global_state::GlobalState;

--- a/src/internal/header.rs
+++ b/src/internal/header.rs
@@ -16,15 +16,32 @@
  */
 
 //! RPM package headers
-
-use super::{tag::Tag, td::TagData};
-use crate::Package;
+use std::ffi::CString;
 use std::mem;
+use std::os::unix::prelude::OsStrExt;
+use std::path::Path;
+
+use super::rc::{RpmErrorKind, RpmReturnCode};
+use super::ts::GlobalTS;
+use super::{tag::Tag, td::TagData};
 
 /// RPM package header
-pub(crate) struct Header(*mut librpm_sys::headerToken_s);
+pub(crate) struct Header(librpm_sys::Header); // *mut librpm_sys::headerToken_s
 
 impl Header {
+    pub(crate) fn new() -> Self {
+        let ffi_header = unsafe { librpm_sys::headerNew() };
+        assert!(!ffi_header.is_null());
+
+        // No need to increment refcount, starts with refcount=1
+        Header(ffi_header)
+    }
+
+    /// Create a Header handle in Rust from a raw pointer
+    ///
+    /// SAFETY: The input pointer must not be used after passing ownership from Rust, except for dropping
+    /// the live reference if one existed. Once the original pointer goes out of scope, Rust should own
+    /// the only reference.
     pub(crate) unsafe fn from_ptr(ffi_header: librpm_sys::Header) -> Self {
         assert!(!ffi_header.is_null());
         // Increment librpm's internal reference count for this header
@@ -32,6 +49,73 @@ impl Header {
             librpm_sys::headerLink(ffi_header);
         }
         Header(ffi_header)
+    }
+
+    /// Get a pointer to the original librpm C struct for use by C functions.
+    ///
+    /// SAFETY: This pointer should not be copied and must not passed to headerFree().
+    pub(crate) unsafe fn as_mut_ptr(&mut self) -> &mut librpm_sys::Header {
+        &mut self.0
+    }
+
+    pub(crate) fn from_file(path: &Path) -> Result<Self, RpmErrorKind> {
+        let mut txn = GlobalTS::create();
+
+        let filename = CString::new(path.as_os_str().as_bytes()).unwrap();
+        let fmode = CString::new("r.ufdio").unwrap();
+
+        // Safety: filename and fmode are valid CStrings kept alive for the call
+        let fd: librpm_sys::FD_t = unsafe { librpm_sys::Fopen(filename.as_ptr(), fmode.as_ptr()) };
+        let mut hdr = Header::new();
+
+        let mut vsflags = librpm_sys::rpmVSFlags_e_RPMVSF_NOHDRCHK
+            | librpm_sys::rpmVSFlags_e_RPMVSF_NOSHA1HEADER
+            | librpm_sys::rpmVSFlags_e_RPMVSF_NOSHA256HEADER
+            | librpm_sys::rpmVSFlags_e_RPMVSF_NOMD5
+            | librpm_sys::rpmVSFlags_e_RPMVSF_NODSAHEADER
+            | librpm_sys::rpmVSFlags_e_RPMVSF_NORSAHEADER
+            | librpm_sys::rpmVSFlags_e_RPMVSF_NODSA
+            | librpm_sys::rpmVSFlags_e_RPMVSF_NORSA;
+
+        #[cfg(has_rpmvsflag_nosha256payload)]
+        {
+            vsflags |= librpm_sys::rpmVSFlags_e_RPMVSF_NOSHA256PAYLOAD;
+        }
+        #[cfg(has_rpmvsflag_nosha512payload)]
+        {
+            vsflags |= librpm_sys::rpmVSFlags_e_RPMVSF_NOSHA512PAYLOAD;
+        }
+        #[cfg(has_rpmvsflag_nosha3_256payload)]
+        {
+            vsflags |= librpm_sys::rpmVSFlags_e_RPMVSF_NOSHA3_256PAYLOAD;
+        }
+        #[cfg(has_rpmvsflag_nosha3_256header)]
+        {
+            vsflags |= librpm_sys::rpmVSFlags_e_RPMVSF_NOSHA3_256HEADER;
+        }
+        #[cfg(has_rpmvsflag_noopenpgp)]
+        {
+            vsflags |= librpm_sys::rpmVSFlags_e_RPMVSF_NOOPENPGP;
+        }
+
+        // Safety: raw_ts and fd are valid pointers obtained above; hdr is
+        // initialized by headerNew(). Fclose is called on all paths after
+        // rpmReadPackageFile returns, regardless of success or failure.
+        unsafe {
+            let raw_ts = txn.as_mut_ptr();
+            librpm_sys::rpmtsSetVSFlags(raw_ts, vsflags);
+
+            let rc = librpm_sys::rpmReadPackageFile(raw_ts, fd, std::ptr::null(), hdr.as_mut_ptr());
+            librpm_sys::Fclose(fd);
+
+            match RpmReturnCode::from_raw(rc) {
+                Some(RpmReturnCode::Ok) => Ok(hdr),
+                Some(RpmReturnCode::NotFound) => Err(RpmErrorKind::NotFound),
+                Some(RpmReturnCode::NotTrusted) => Err(RpmErrorKind::NotTrusted),
+                Some(RpmReturnCode::NoKey) => Err(RpmErrorKind::NoKey),
+                _ => Err(RpmErrorKind::Fail),
+            }
+        }
     }
 
     /// Get the data that corresponds to the given header tag.
@@ -82,22 +166,17 @@ impl Header {
 
         Some(data)
     }
+}
 
-    /// Convert this `Header` into a `Package`
-    pub(crate) fn to_package(&self) -> Package {
-        Package {
-            name: self.get(Tag::NAME).unwrap().as_str().unwrap().to_owned(),
-            epoch: self
-                .get(Tag::EPOCH)
-                .map(|d| d.to_int32().unwrap().to_owned()),
-            version: self.get(Tag::VERSION).unwrap().as_str().unwrap().to_owned(),
-            release: self.get(Tag::RELEASE).unwrap().as_str().unwrap().to_owned(),
-            arch: self.get(Tag::ARCH).map(|d| d.as_str().unwrap().to_owned()),
-            license: self.get(Tag::LICENSE).unwrap().as_str().unwrap().to_owned(),
-            summary: self.get(Tag::SUMMARY).unwrap().as_str().unwrap().into(),
-            description: self.get(Tag::DESCRIPTION).unwrap().as_str().unwrap().into(),
-            buildtime: self.get(Tag::BUILDTIME).unwrap().to_int32().unwrap(),
+impl Clone for Header {
+    fn clone(&self) -> Self {
+        // Safety: self.0 is a valid header pointer (invariant of Header).
+        // headerLink increments the refcount; Drop calls headerFree to
+        // decrement it, so the new Header owns one reference.
+        unsafe {
+            librpm_sys::headerLink(self.0);
         }
+        Header(self.0)
     }
 }
 

--- a/src/internal/rc.rs
+++ b/src/internal/rc.rs
@@ -1,0 +1,35 @@
+/// Errors returned by librpm operations such as reading package files
+#[derive(Debug)]
+pub enum RpmErrorKind {
+    /// Generic not found code
+    NotFound,
+    /// Generic failure code
+    Fail,
+    /// Signature is OK but key is not trusted
+    NotTrusted,
+    /// No public key available to verify the signature
+    NoKey,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum RpmReturnCode {
+    Ok = librpm_sys::rpmRC_e_RPMRC_OK,
+    NotFound = librpm_sys::rpmRC_e_RPMRC_NOTFOUND,
+    Fail = librpm_sys::rpmRC_e_RPMRC_FAIL,
+    NotTrusted = librpm_sys::rpmRC_e_RPMRC_NOTTRUSTED,
+    NoKey = librpm_sys::rpmRC_e_RPMRC_NOKEY,
+}
+
+impl RpmReturnCode {
+    pub fn from_raw(value: u32) -> Option<Self> {
+        match value {
+            librpm_sys::rpmRC_e_RPMRC_OK => Some(Self::Ok),
+            librpm_sys::rpmRC_e_RPMRC_NOTFOUND => Some(Self::NotFound),
+            librpm_sys::rpmRC_e_RPMRC_FAIL => Some(Self::Fail),
+            librpm_sys::rpmRC_e_RPMRC_NOTTRUSTED => Some(Self::NotTrusted),
+            librpm_sys::rpmRC_e_RPMRC_NOKEY => Some(Self::NoKey),
+            _ => None,
+        }
+    }
+}

--- a/src/internal/td.rs
+++ b/src/internal/td.rs
@@ -27,7 +27,7 @@ use std::{slice, str};
 
 /// Data found in RPM headers, associated with a particular `Tag` value.
 #[derive(Debug)]
-pub(crate) enum TagData<'hdr> {
+pub enum TagData<'hdr> {
     /// No data associated with this tag
     Null,
 

--- a/src/internal/ts.rs
+++ b/src/internal/ts.rs
@@ -44,7 +44,7 @@ impl TransactionSet {
 impl Drop for TransactionSet {
     fn drop(&mut self) {
         unsafe {
-            librpm_sys::rpmtsFree(*self.0.get_mut());
+            librpm_sys::rpmtsFree(*self.as_mut_ptr());
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,3 +51,8 @@ pub mod macro_context;
 pub mod package;
 
 pub use self::{db::Index, error::Error, macro_context::MacroContext, package::Package};
+
+// Re-export types used in public API
+pub use self::internal::rc::RpmErrorKind;
+pub use self::internal::tag::Tag;
+pub use self::internal::td::TagData;

--- a/src/package.rs
+++ b/src/package.rs
@@ -16,91 +16,179 @@
  */
 
 //! RPM package type: represents `.rpm` files or entries in the RPM database
+use crate::internal::header::Header;
+use crate::{RpmErrorKind, Tag, TagData};
 use std::convert::TryFrom;
-use std::{fmt, time};
+use std::hash::{Hash, Hasher};
+use std::{fmt, path::Path, time};
 
 /// RPM packages
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+///
+/// A thin wrapper around a librpm header. Accessors perform tag lookups
+/// on demand rather than copying data out of the header up front.
 pub struct Package {
-    pub(crate) name: String,
-    pub(crate) epoch: Option<i32>,
-    pub(crate) version: String,
-    pub(crate) release: String,
-    pub(crate) arch: Option<String>,
-    pub(crate) license: String,
-    pub(crate) summary: String,
-    pub(crate) description: String,
-    pub(crate) buildtime: i32,
+    header: Header,
 }
 
 impl Package {
+    pub(crate) fn from_header(h: &Header) -> Self {
+        Package { header: h.clone() }
+    }
+
+    /// Create a Package by reading an `.rpm` file
+    pub fn from_file(path: &Path) -> Result<Self, RpmErrorKind> {
+        let header = Header::from_file(path)?;
+        Ok(Package { header })
+    }
+
+    /// Look up raw tag data from the underlying RPM header
+    pub fn get(&self, tag: Tag) -> Option<TagData<'_>> {
+        self.header.get(tag)
+    }
+
     /// Name of the package
     pub fn name(&self) -> &str {
-        &self.name
+        self.header
+            .get(Tag::NAME)
+            .expect("NAME tag missing")
+            .as_str()
+            .expect("NAME tag is not a string")
     }
 
     /// Epoch of the package
     pub fn epoch(&self) -> Option<i32> {
-        self.epoch
+        self.header
+            .get(Tag::EPOCH)
+            .map(|d| d.to_int32().expect("EPOCH tag is not an int32"))
     }
 
     /// Version of the package
     pub fn version(&self) -> &str {
-        &self.version
+        self.header
+            .get(Tag::VERSION)
+            .expect("VERSION tag missing")
+            .as_str()
+            .expect("VERSION tag is not a string")
     }
 
     /// Release of the package
     pub fn release(&self) -> &str {
-        &self.release
+        self.header
+            .get(Tag::RELEASE)
+            .expect("RELEASE tag missing")
+            .as_str()
+            .expect("RELEASE tag is not a string")
     }
 
     /// Arch of the package
     pub fn arch(&self) -> Option<&str> {
-        self.arch.as_deref()
+        self.header
+            .get(Tag::ARCH)
+            .map(|d| d.as_str().expect("ARCH tag is not a string"))
     }
 
     /// EVR (epoch, version, release) of the package
     pub fn evr(&self) -> String {
-        if let Some(epoch) = &self.epoch {
-            format!("{}:{}-{}", epoch, self.version, self.release)
+        if let Some(epoch) = self.epoch() {
+            format!("{}:{}-{}", epoch, self.version(), self.release())
         } else {
-            format!("{}-{}", self.version, self.release)
+            format!("{}-{}", self.version(), self.release())
         }
     }
 
     /// NEVRA (name, epoch, version, release, arch) of the package
     pub fn nevra(&self) -> String {
-        if let Some(arch) = &self.arch {
-            format!("{}-{}.{}", self.name, self.evr(), arch)
+        if let Some(arch) = self.arch() {
+            format!("{}-{}.{}", self.name(), self.evr(), arch)
         } else {
-            format!("{}-{}", self.name, self.evr())
+            format!("{}-{}", self.name(), self.evr())
         }
     }
 
     /// License of the package
     pub fn license(&self) -> &str {
-        &self.license
+        self.header
+            .get(Tag::LICENSE)
+            .expect("LICENSE tag missing")
+            .as_str()
+            .expect("LICENSE tag is not a string")
     }
 
     /// Succinct description of the package
     pub fn summary(&self) -> &str {
-        &self.summary
+        self.header
+            .get(Tag::SUMMARY)
+            .expect("SUMMARY tag missing")
+            .as_str()
+            .expect("SUMMARY tag is not a string")
     }
 
     /// Longer description of the package
     pub fn description(&self) -> &str {
-        &self.description
+        self.header
+            .get(Tag::DESCRIPTION)
+            .expect("DESCRIPTION tag missing")
+            .as_str()
+            .expect("DESCRIPTION tag is not a string")
     }
 
     /// Buildtime of the package
     pub fn buildtime(&self) -> time::SystemTime {
-        let buildtime = u64::try_from(self.buildtime).expect("negative build time");
+        let buildtime = self
+            .header
+            .get(Tag::BUILDTIME)
+            .expect("BUILDTIME tag missing")
+            .to_int32()
+            .expect("BUILDTIME tag is not an int32");
+        let buildtime = u64::try_from(buildtime).expect("negative build time");
         time::SystemTime::UNIX_EPOCH + time::Duration::new(buildtime, 0)
+    }
+}
+
+impl Clone for Package {
+    fn clone(&self) -> Self {
+        Package {
+            header: self.header.clone(),
+        }
+    }
+}
+
+impl fmt::Debug for Package {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Package")
+            .field("name", &self.name())
+            .field("epoch", &self.epoch())
+            .field("version", &self.version())
+            .field("release", &self.release())
+            .field("arch", &self.arch())
+            .finish()
     }
 }
 
 impl fmt::Display for Package {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.nevra())
+    }
+}
+
+impl PartialEq for Package {
+    fn eq(&self, other: &Self) -> bool {
+        self.name() == other.name()
+            && self.epoch() == other.epoch()
+            && self.version() == other.version()
+            && self.release() == other.release()
+            && self.arch() == other.arch()
+    }
+}
+
+impl Eq for Package {}
+
+impl Hash for Package {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.name().hash(state);
+        self.epoch().hash(state);
+        self.version().hash(state);
+        self.release().hash(state);
+        self.arch().hash(state);
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,0 +1,96 @@
+//! librpm.rs integration tests
+
+use librpm::{Index, config};
+use std::process::Command;
+use std::sync::Once;
+
+static CONFIGURE: Once = Once::new();
+
+// Read the default config
+// TODO: create a mock RPM database for testing
+fn configure() {
+    CONFIGURE.call_once(|| {
+        config::read_file(None).unwrap();
+    });
+}
+
+fn fetch_package_info(package_name: &str, query_param: &str) -> Option<String> {
+    let rpm_info = Command::new("rpm")
+        .arg("-q")
+        .arg(package_name)
+        .arg(format!("--queryformat=%{{{}}}", query_param))
+        .output()
+        .unwrap()
+        .stdout;
+
+    let text = String::from_utf8(rpm_info).unwrap();
+    Some(text).filter(|c| c != "(none)" && c != "")
+}
+
+#[test]
+fn db_find_test() {
+    configure();
+
+    let package_name = "rpm-devel";
+    let package_nevra = fetch_package_info(package_name, "NEVRA").unwrap();
+
+    let mut matches = Index::Name.find(package_name);
+
+    if let Some(package) = matches.next() {
+        assert_eq!(package.name(), "rpm-devel");
+        assert_eq!(
+            package.epoch(),
+            fetch_package_info(package_name, "EPOCH").map(|s| s.parse::<i32>().unwrap())
+        );
+        assert_eq!(
+            package.version(),
+            fetch_package_info(package_name, "VERSION").unwrap()
+        );
+        assert_eq!(
+            package.release(),
+            fetch_package_info(package_name, "RELEASE").unwrap()
+        );
+        assert_eq!(
+            package.summary(),
+            fetch_package_info(package_name, "SUMMARY").unwrap()
+        );
+        assert_eq!(
+            package.license(),
+            fetch_package_info(package_name, "LICENSE").unwrap()
+        );
+
+        assert_eq!(package.nevra(), package_nevra);
+        assert_eq!(package.to_string(), package_nevra);
+
+        assert!(matches.next().is_none(), "expected one result, got more!");
+    } else {
+        if librpm::db::installed_packages().count() == 0 {
+            eprintln!("*** warning: No RPMs installed! Tests skipped!")
+        } else {
+            panic!("some RPMs installed, but not `rpm-devel`?!");
+        }
+    }
+}
+
+// TODO: This will deadlock: https://github.com/rpm-software-management/librpm.rs/issues/15
+// #[test]
+// fn db_find_test_multiple() {
+
+//     configure();
+
+//     let mut matches = Index::Name.find("glibc-common");
+//     if let Some(package) = matches.next() {
+//         assert_eq!(package.name(), "glibc-common");
+//         assert!(matches.next().is_none(), "expected one result, got more!");
+//     } else {
+//         panic!("glibc-common package not installed, are you running on RPM hosted system (RHEL, Fedora, CentOS)?");
+//     }
+
+//     let mut matches = Index::Name.find("glibc");
+//     if let Some(package) = matches.next() {
+//         assert_eq!(package.name(), "glibc");
+//         assert!(matches.next().is_none(), "expected one result, got more!");
+//     } else {
+//         panic!("glibc package not installed, are you running on RPM hosted system (RHEL, Fedora, CentOS)?");
+//     }
+// }

--- a/tests/test-fedora-44.rs
+++ b/tests/test-fedora-44.rs
@@ -1,4 +1,4 @@
-use librpm::{Package, config::set_db_path, db::installed_packages};
+use librpm::{Package, Tag, config::set_db_path, db::installed_packages};
 
 mod common;
 
@@ -25,5 +25,36 @@ fn test_fedora_44_rpm_database() {
     assert_eq!(
         sample_package.description(),
         "alternatives creates, removes, maintains and displays information about the\nsymbolic links comprising the alternatives system. It is possible for several\nprograms fulfilling the same or similar functions to be installed on a single\nsystem at the same time."
+    );
+}
+
+#[test]
+fn test_fedora_44_array_tag_data() {
+    common::configure();
+    set_db_path(&common::get_assets_path().join("fedora-44")).unwrap();
+
+    let mut packages: Vec<Package> = installed_packages().collect();
+    packages.sort_by_key(|p| p.name().to_string());
+
+    let pkg = &packages[0]; // "alternatives"
+    assert_eq!(pkg.name(), "alternatives");
+
+    // BASENAMES is a STRING_ARRAY tag — the current code handles these correctly
+    // because string_array() iterates with rpmtdNextString
+    let basenames = pkg.get(Tag::BASENAMES).expect("BASENAMES tag missing");
+    let basenames = basenames
+        .as_str_array()
+        .expect("BASENAMES should be a string array");
+    assert_eq!(basenames.len(), 12, "alternatives package has 12 files");
+
+    // FILESIZES is an INT32 tag with count > 1 (one entry per file).
+    // BUG: the current TagData::int32() implementation reads only the first
+    // element as a scalar Int32, discarding the remaining entries.
+    // This is the bug fixed by the TagData array rework — when that lands,
+    // this assertion should change to verify all 12 entries are returned.
+    let filesizes = pkg.get(Tag::FILESIZES).expect("FILESIZES tag missing");
+    assert!(
+        filesizes.to_int32().is_some(),
+        "FILESIZES currently returns a scalar Int32 (known bug: should be an array of 12 values)"
     );
 }


### PR DESCRIPTION
It makes more sense for Package to know details about Header than the other way around.  And we probably want some permutation of a `Package::from_file()` function to exist which will involve using functions that deal with headers.

edit: 5 years later

additional changes:

Package no longer copies all tag values into owned String fields up
front. Instead it holds a reference-counted Header and performs tag
lookups on demand through the existing accessors.

Header gains a Clone impl that increments librpm's internal reference
count via headerLink(), matching the existing Drop impl that calls
headerFree().

Package's derived trait impls (Clone, Debug, PartialEq, Eq, Hash) are
replaced with manual implementations that delegate to tag lookups.
PartialEq and Hash compare by NEVRA components (name, epoch, version,
release, arch).

New public API:
- Package::from_file() reads an .rpm file directly into a Package
- Package::get() exposes raw tag data access via Tag and TagData,
  both of which are now part of the public API
- RpmErrorKind is re-exported for from_file() error handling