### PR TITLE
fix: remove the unnecessary path segment

### DIFF
--- a/src/package.rs
+++ b/src/package.rs
@@ -99,7 +99,7 @@ impl Package {
     }
 }
 
-impl std::fmt::Display for Package {
+impl fmt::Display for Package {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.nevra())
     }


### PR DESCRIPTION
no warning, no fix help, that's fill better:

```
note: the lint level is defined here
   --> librpm.rs/src/lib.rs:32:38
    |
32  | #![warn(missing_docs, trivial_casts, unused_qualifications)]
    |                                      ^^^^^^^^^^^^^^^^^^^^^
help: remove the unnecessary path segments
    |
102 - impl std::fmt::Display for Package {
102 + impl fmt::Display for Package {
    |
```