### PR TITLE
Remove unused regex feature

### DIFF
--- a/src/internal/iterator.rs
+++ b/src/internal/iterator.rs
@@ -18,8 +18,6 @@
 //! Iterators for matches in the RPM database
 
 use super::{header::Header, tag::DBIndexTag, ts::GlobalTS};
-#[cfg(feature = "regex")]
-use regex::Regex;
 use std::{os::raw::c_void, ptr};
 use streaming_iterator::StreamingIterator;
 


### PR DESCRIPTION
Fixes clippy warning about 'cfg' with an undeclared feature name. Regex is never actually used at the moment so it can be simply removed.