### PR TITLE
Extend Package with the file name information

### DIFF
--- a/src/internal/header.rs
+++ b/src/internal/header.rs
@@ -19,7 +19,11 @@
 
 use super::{tag::Tag, td::TagData};
 use crate::Package;
+use std::ffi::{CStr, OsStr};
 use std::mem;
+use std::os::unix::ffi::OsStrExt;
+use std::path::PathBuf;
+use std::ptr::null_mut;
 
 /// RPM package header
 pub(crate) struct Header(*mut librpm_sys::headerToken_s);
@@ -86,6 +90,7 @@ impl Header {
             summary: self.get(Tag::SUMMARY).unwrap().as_str().unwrap().into(),
             description: self.get(Tag::DESCRIPTION).unwrap().as_str().unwrap().into(),
             buildtime: self.get(Tag::BUILDTIME).unwrap().to_int32().unwrap(),
+            filenames: FileNameIterator::from_header(self).collect(),
         }
     }
 }
@@ -95,6 +100,59 @@ impl Drop for Header {
         // Decrement librpm's internal reference count for this header
         unsafe {
             librpm_sys::headerFree(self.0);
+        }
+    }
+}
+
+/// Iterator over a single file info query
+struct FileNameIterator {
+    fi: *mut librpm_sys::rpmfi_s,
+}
+
+impl Iterator for FileNameIterator {
+    type Item = PathBuf;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // SAFETY: see `Self::from_header`
+        if unsafe { librpm_sys::rpmfiNext(self.fi) } < 0 {
+            return None;
+        }
+        // SAFETY: see `Self::from_header`. Return value can
+        // be an arbitrary null-terminated byte sequence.
+        // Return value (`name`) stays valid until the next rpmfiFn call.
+        let name = unsafe {
+            let name = librpm_sys::rpmfiFN(self.fi);
+            assert!(!name.is_null());
+            CStr::from_ptr(name).to_bytes()
+        };
+        let name = PathBuf::from(OsStr::from_bytes(name));
+        Some(name)
+    }
+}
+
+impl FileNameIterator {
+    fn from_header(header: &Header) -> Self {
+        // SAFETY: once constructed, rpmfiNew return value stays valid
+        // until rpmfiFree is called. Additionally:
+        // 1. Ensure it is not NULL so that a valid Rust reference can be created
+        // 2. Memory-safety of fi is not dependent on the header per docs, however,
+        //    it does not mean actual file list will be up to date per the latest package
+        //    version. Right now it doesn't matter as we collect file names eagerly during
+        //    construction.
+        let fi = unsafe {
+            let fi = librpm_sys::rpmfiNew(null_mut(), header.0, 0, 0);
+            assert!(!fi.is_null());
+            fi
+        };
+        FileNameIterator { fi }
+    }
+}
+
+impl Drop for FileNameIterator {
+    fn drop(&mut self) {
+        unsafe {
+            // SAFETY: see `Self::from_header`
+            librpm_sys::rpmfiFree(self.fi);
         }
     }
 }

--- a/src/package.rs
+++ b/src/package.rs
@@ -31,6 +31,7 @@ pub struct Package {
     pub(crate) summary: String,
     pub(crate) description: String,
     pub(crate) buildtime: i32,
+    pub(crate) filenames: Vec<std::path::PathBuf>,
 }
 
 impl Package {
@@ -96,6 +97,11 @@ impl Package {
     pub fn buildtime(&self) -> time::SystemTime {
         let buildtime = u64::try_from(self.buildtime).expect("negative build time");
         time::SystemTime::UNIX_EPOCH + time::Duration::new(buildtime, 0)
+    }
+
+    /// Full paths of all files installed by the package
+    pub fn filenames(&self) -> &Vec<std::path::PathBuf> {
+        &self.filenames
     }
 }
 

--- a/tests/test-current-system.rs
+++ b/tests/test-current-system.rs
@@ -19,6 +19,8 @@
 
 use librpm::Package;
 use librpm::db::installed_packages;
+use std::io::BufRead;
+use std::path::PathBuf;
 use std::process::Command;
 
 mod common;
@@ -29,6 +31,7 @@ struct PartialPackage {
     version: String,
     release: String,
     summary: String,
+    filenames: Vec<PathBuf>,
 }
 
 fn fetch_system_packages() -> Vec<PartialPackage> {
@@ -48,11 +51,30 @@ fn fetch_system_packages() -> Vec<PartialPackage> {
         let version = parts.next().unwrap();
         let release = parts.next().unwrap();
         let summary = parts.next().unwrap();
+        let filenames: Vec<_> = Command::new("rpm")
+            .arg("-ql")
+            .arg(name)
+            .output()
+            .unwrap()
+            .stdout
+            .lines()
+            .filter_map(|line| match line {
+                Ok(l) => {
+                    if l == "(contains no files)" {
+                        None
+                    } else {
+                        Some(PathBuf::from(l))
+                    }
+                }
+                Err(_) => None,
+            })
+            .collect();
         packages.push(PartialPackage {
             name: name.to_string(),
             version: version.to_string(),
             release: release.to_string(),
             summary: summary.to_string(),
+            filenames,
         });
     }
 
@@ -80,5 +102,6 @@ fn test_against_installed_packages() {
         assert_eq!(expected.version, found.version());
         assert_eq!(expected.release, found.release());
         assert_eq!(expected.summary, found.summary());
+        assert_eq!(&expected.filenames, found.filenames());
     }
 }


### PR DESCRIPTION
Based on rpmfiNext/rpmfiNext which provide full paths independent of underlying tag format used in the database.

This implementation has one issue - it panics on non-utf-8 file names which is a legitimate scenario, although unlikely for any file owned by a package manager. However, providing a more flexible `Iterator<Item = Result<String>>` requires refactoring relation between Package and Header and better done as a follow-up change. This implementation is simpler and will work in most cases.