### PR TITLE
Implement 'string_array' in td.rs

### DIFF
--- a/src/internal/header.rs
+++ b/src/internal/header.rs
@@ -63,7 +63,9 @@ impl Header {
             librpm_sys::rpmTagType_e_RPM_INT32_TYPE => unsafe { TagData::int32(&td) },
             librpm_sys::rpmTagType_e_RPM_INT64_TYPE => unsafe { TagData::int64(&td) },
             librpm_sys::rpmTagType_e_RPM_STRING_TYPE => unsafe { TagData::string(&td) },
-            librpm_sys::rpmTagType_e_RPM_STRING_ARRAY_TYPE => unsafe { TagData::string_array(&td) },
+            librpm_sys::rpmTagType_e_RPM_STRING_ARRAY_TYPE => unsafe {
+                TagData::string_array(&mut td)
+            },
             librpm_sys::rpmTagType_e_RPM_I18NSTRING_TYPE => unsafe { TagData::i18n_string(&td) },
             librpm_sys::rpmTagType_e_RPM_BIN_TYPE => unsafe { TagData::bin(&td) },
             other => panic!("unsupported rpmtd tag type: {other}"),

--- a/src/internal/td.rs
+++ b/src/internal/td.rs
@@ -121,8 +121,25 @@ impl<'hdr> TagData<'hdr> {
     }
 
     /// Convert an `rpmtd_s` into a `StrArray`
-    pub(crate) unsafe fn string_array(_td: &librpm_sys::rpmtd_s) -> Self {
-        panic!("RPM_STRING_ARRAY_TYPE unsupported!");
+    pub(crate) unsafe fn string_array(td: &mut librpm_sys::rpmtd_s) -> Self {
+        assert_eq!(td.type_, TagType::STRING_ARRAY as u32);
+        let mut result = Vec::new();
+        loop {
+            // Always safe with a valid 'td':
+            let cstr = unsafe { librpm_sys::rpmtdNextString(td) };
+            if cstr.is_null() {
+                break;
+            }
+            let cstr = unsafe { CStr::from_ptr(cstr as *const c_char) };
+            // Same as with 'string'
+            result.push(str::from_utf8(cstr.to_bytes()).unwrap_or_else(|e| {
+                panic!(
+                    "failed to decode an item from RPM_STRING_ARRAY as UTF-8 (tag: {}): {}",
+                    td.tag, e
+                );
+            }));
+        }
+        TagData::StrArray(result)
     }
 
     /// Convert an `rpmtd_s` into an `I18NStr`


### PR DESCRIPTION
It may be a better alternative to provide an iterator over array items instead rather, than allocating a vector each time. However I wanted to avoid modifying existing API without a specific need and it was already defined as a vector.