### PR TITLE
fix: replace dead rustrpm.org URLs with docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ categories = ["api-bindings", "os", "parsing"]
 keywords = ["rpm", "linux", "redhat", "fedora", "centos"]
 readme = "README.md"
 homepage = "https://github.com/rpm-software-management/librpm.rs/"
-documentation = "https://rustrpm.org/librpm/"
+documentation = "https://github.com/rpm-software-management/librpm.rs"
 edition = "2024"
 rust-version = "1.85"
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The [librpm] C library (available in the `rpm-devel` RPM package) exposes a
 programmatic interface to the [RPM Package Manager], and this crate aims to
 provide a safe, idiomatic Rust wrapper.
 
-[Documentation](https://rustrpm.org/librpm/)
+[Documentation](https://github.com/rpm-software-management/librpm.rs)
 
 [librpm]: http://ftp.rpm.org/api/4.14.0/
 [RPM Package Manager]: http://rpm.org/

--- a/librpm-sys/Cargo.toml
+++ b/librpm-sys/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["rpm", "linux", "redhat", "fedora", "centos"]
 readme = "README.md"
 homepage = "https://github.com/rpm-software-management/librpm.rs/"
 repository = "https://github.com/rpm-software-management/librpm.rs/tree/master/librpm-sys"
-documentation = "https://rustrpm.org/librpm_sys/"
+documentation = "https://github.com/rpm-software-management/librpm.rs/tree/main/librpm-sys"
 edition = "2024"
 rust-version = "1.85"
 

--- a/librpm-sys/README.md
+++ b/librpm-sys/README.md
@@ -12,7 +12,7 @@ This crate isn't intended to be used directly, but instead provides an unsafe,
 low-level binding used by the higher level **librpm** crate, which aims to
 provide a safe, idiomatic, high-level binding to the C library:
 
-https://rustrpm.org/
+https://github.com/rpm-software-management/librpm.rs
 
 If you're intending to add a feature to the **librpm** crate however, you have
 come to the right place. You can find documentation here:
@@ -40,7 +40,7 @@ If a copy of the MPL was not distributed with this file, You can obtain one at <
 
 [//]: # (general links)
 
-[Documentation]: https://rustrpm.org/librpm-sys/
+[Documentation]: https://github.com/rpm-software-management/librpm.rs/tree/main/librpm-sys
 [librpm C library]: http://ftp.rpm.org/api/4.14.0/
 [RPM Package Manager]: http://rpm.org/
 [Mozilla Public License, v. 2.0]: https://github.com/rpm-software-management/librpm.rs/blob/main/LICENSE

--- a/librpm-sys/src/lib.rs
+++ b/librpm-sys/src/lib.rs
@@ -21,7 +21,7 @@
 //! This crate isn't intended to be used directly, but instead provides the
 //! low-level binding which is used by the idiomatic librpm crate.
 
-#![doc(html_root_url = "https://rustrpm.org/librpm_sys/")]
+#![doc(html_root_url = "https://github.com/rpm-software-management/librpm.rs/tree/main/librpm-sys")]
 #![allow(
     non_upper_case_globals,
     non_camel_case_types,

--- a/librpmbuild-sys/Cargo.toml
+++ b/librpmbuild-sys/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["rpm", "linux", "redhat", "fedora", "centos"]
 readme = "README.md"
 homepage = "https://github.com/rpm-software-management/librpm.rs/"
 repository = "https://github.com/rpm-software-management/librpm.rs/tree/master/librpmbuild-sys"
-documentation = "https://rustrpm.org/librpmbuild_sys/"
+documentation = "https://github.com/rpm-software-management/librpm.rs/tree/main/librpmbuild-sys"
 edition = "2024"
 rust-version = "1.85"
 

--- a/librpmbuild-sys/README.md
+++ b/librpmbuild-sys/README.md
@@ -12,7 +12,7 @@ This crate isn't intended to be used directly, but instead provides an unsafe,
 low-level binding used by the higher level **librpm** crate, which aims to
 provide a safe, idiomatic, high-level binding to the C library:
 
-https://rustrpm.org/
+https://github.com/rpm-software-management/librpm.rs
 
 ## License
 

--- a/librpmbuild-sys/src/lib.rs
+++ b/librpmbuild-sys/src/lib.rs
@@ -22,7 +22,9 @@
 //! This crate isn't intended to be used directly, but instead provides the
 //! low-level binding which is used by the idiomatic librpm crate.
 
-#![doc(html_root_url = "https://github.com/rpm-software-management/librpm.rs/tree/main/librpmbuild-sys")]
+#![doc(
+    html_root_url = "https://github.com/rpm-software-management/librpm.rs/tree/main/librpmbuild-sys"
+)]
 #![allow(non_upper_case_globals, non_camel_case_types, non_snake_case)]
 
 // Bindings to librpmbuild.so

--- a/librpmbuild-sys/src/lib.rs
+++ b/librpmbuild-sys/src/lib.rs
@@ -22,7 +22,7 @@
 //! This crate isn't intended to be used directly, but instead provides the
 //! low-level binding which is used by the idiomatic librpm crate.
 
-#![doc(html_root_url = "https://rustrpm.org/librpmbuild_sys/")]
+#![doc(html_root_url = "https://github.com/rpm-software-management/librpm.rs/tree/main/librpmbuild-sys")]
 #![allow(non_upper_case_globals, non_camel_case_types, non_snake_case)]
 
 // Bindings to librpmbuild.so

--- a/librpmsign-sys/Cargo.toml
+++ b/librpmsign-sys/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["rpm", "linux", "redhat", "fedora", "centos"]
 readme = "README.md"
 homepage = "https://github.com/rpm-software-management/librpm.rs/"
 repository = "https://github.com/rpm-software-management/librpm.rs/tree/master/librpmsign-sys"
-documentation = "https://rustrpm.org/librpmsign_sys/"
+documentation = "https://github.com/rpm-software-management/librpm.rs/tree/main/librpmsign-sys"
 edition = "2024"
 rust-version = "1.85"
 

--- a/librpmsign-sys/README.md
+++ b/librpmsign-sys/README.md
@@ -12,7 +12,7 @@ This crate isn't intended to be used directly, but instead provides an unsafe,
 low-level binding used by the higher level **librpm** crate, which aims to
 provide a safe, idiomatic, high-level binding to the C library:
 
-https://rustrpm.org/
+https://github.com/rpm-software-management/librpm.rs
 
 ## License
 

--- a/librpmsign-sys/src/lib.rs
+++ b/librpmsign-sys/src/lib.rs
@@ -22,7 +22,9 @@
 //! This crate isn't intended to be used directly, but instead provides the
 //! low-level binding which is used by the idiomatic librpm crate.
 
-#![doc(html_root_url = "https://github.com/rpm-software-management/librpm.rs/tree/main/librpmsign-sys")]
+#![doc(
+    html_root_url = "https://github.com/rpm-software-management/librpm.rs/tree/main/librpmsign-sys"
+)]
 #![allow(non_upper_case_globals, non_camel_case_types, non_snake_case)]
 
 // Bindings to librpmsign.so

--- a/librpmsign-sys/src/lib.rs
+++ b/librpmsign-sys/src/lib.rs
@@ -22,7 +22,7 @@
 //! This crate isn't intended to be used directly, but instead provides the
 //! low-level binding which is used by the idiomatic librpm crate.
 
-#![doc(html_root_url = "https://rustrpm.org/librpmsign_sys/")]
+#![doc(html_root_url = "https://github.com/rpm-software-management/librpm.rs/tree/main/librpmsign-sys")]
 #![allow(non_upper_case_globals, non_camel_case_types, non_snake_case)]
 
 // Bindings to librpmsign.so

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,9 +26,7 @@
 //! See the `librpm::db::Database` type for examples of how to interact with
 //! the RPM database.
 //!
-//! [librpm-sys]: https://rustrpm.org/librpm_sys/index.html
-
-#![doc(html_root_url = "https://rustrpm.org/librpm/")]
+//! [librpm-sys]: https://github.com/rpm-software-management/librpm.rs/tree/main/librpm-sys
 #![warn(missing_docs, trivial_casts, unused_qualifications)]
 
 /// Error types (defined first due to macros)


### PR DESCRIPTION
The `rustrpm.org` domain is no longer serving documentation content — all pages return empty responses, causing documentation links throughout the project to be broken.

This replaces every `rustrpm.org` reference with the corresponding `docs.rs` URL:

- `Cargo.toml` `documentation` fields for librpm, librpm-sys, librpmbuild-sys, librpmsign-sys
- `#![doc(html_root_url)]` attributes in all crate root `lib.rs` files
- Documentation links in all README files
- Inline doc comment links in `src/lib.rs`

Fixes #49
Fixes #20