### PR TITLE
fix: correct typo in librpm-sys and librpmbuild-sys comments

### DIFF
--- a/librpm-sys/src/lib.rs
+++ b/librpm-sys/src/lib.rs
@@ -47,7 +47,7 @@ include!(concat!(env!("OUT_DIR"), "/binding.rs"));
 //
 // To work around the problem, we blacklist the type in `build.rs`, and
 // include a (hopefully) equivalent one which actually compiles, namely by
-// removing the `__BindgenBitfieldUnit` wraper around `[u8; 44]`, which
+// removing the `__BindgenBitfieldUnit` wrapper around `[u8; 44]`, which
 // should hopefully(???) result in an equivalent-sized type.
 //
 // `struct timex` is used only one place in the generated binding: as a

--- a/librpmbuild-sys/src/lib.rs
+++ b/librpmbuild-sys/src/lib.rs
@@ -42,7 +42,7 @@ include!(concat!(env!("OUT_DIR"), "/binding.rs"));
 //
 // To work around the problem, we blacklist the type in `build.rs`, and
 // include a (hopefully) equivalent one which actually compiles, namely by
-// removing the `__BindgenBitfieldUnit` wraper around `[u8; 44]`, which
+// removing the `__BindgenBitfieldUnit` wrapper around `[u8; 44]`, which
 // should hopefully(???) result in an equivalent-sized type.
 //
 // `struct timex` is used only one place in the generated binding: as a


### PR DESCRIPTION
Fix spelling error "wraper" -> "wrapper" in code comments in
`librpm-sys/src/lib.rs` and `librpmbuild-sys/src/lib.rs`.

Both files contain the same comment block describing a workaround
for a bindgen issue with `struct timex`, where "wrapper" was
misspelled as "wraper".