### PR TITLE
Add package signing wrappers (librpmsign) + examples

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Macro expansion utilities - `MacroContext::expand()` expands `%{name}` expressions,
   `MacroContext::is_defined()` tests for macro existence, and
   `macro_context::expand_numeric()` returns macro values as integers
+* `sign` feature: package signing and signature removal via `librpmsign` -
+  `sign_package()`, `del_sign()`, `del_file_sign()` with builder-style `SignArgs`
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -109,6 +136,7 @@ dependencies = [
  "librpmsign-sys",
  "once_cell",
  "streaming-iterator",
+ "tempfile",
 ]
 
 [[package]]
@@ -131,6 +159,12 @@ version = "0.2.0-pre"
 dependencies = [
  "bindgen",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -195,6 +229,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "regex"
 version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,6 +270,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,6 +306,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,12 +331,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
  "windows_i686_gnu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,12 @@ streaming-iterator = "0.1.5"
 
 [features]
 test-current-system = []
+sign = ["dep:librpmsign-sys"]
 
-default = []
+default = ["sign"]
+
+[dev-dependencies]
+tempfile = "3"
 
 [lints.rust]
 # WARNING: this also silences typos in #[cfg(…)] attributes.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ RHEL 8 support may be added in the future, but is not a current priority.
 - [x] Version comparison support (i.e. dependency sets)
 - [x] RPM reader API (i.e. for `.rpm` files)
 - [ ] RPM builder API (i.e. `librpmbuild`)
-- [ ] RPM signing API (i.e. `librpmsign`)
+- [x] RPM signing API (i.e. `librpmsign`)
 
 ## License
 

--- a/examples/database_query.rs
+++ b/examples/database_query.rs
@@ -1,0 +1,19 @@
+//! Query the installed RPM package database.
+//!
+//! Run with: cargo run --example database_query
+
+fn main() {
+    librpm::init().expect("failed to initialize librpm");
+
+    let db = librpm::Db::open().expect("failed to open RPM database");
+
+    println!("Looking up 'rpm' in the database...");
+    for pkg in db.find(librpm::Index::Name, "rpm") {
+        println!("  found: {} ({})", pkg.nevra(), pkg.summary());
+    }
+
+    println!(
+        "\nTotal installed packages: {}",
+        db.installed_packages().count()
+    );
+}

--- a/examples/package_reading.rs
+++ b/examples/package_reading.rs
@@ -1,0 +1,27 @@
+//! Read metadata from an .rpm file.
+//!
+//! Run with: cargo run --example package_reading
+
+use std::path::Path;
+
+fn main() {
+    librpm::init().expect("failed to initialize librpm");
+
+    let rpm_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("testdata/rpms/rpm-basic-with-rsa4096-2.3.4-5.el9.noarch.rpm");
+
+    let pkg = librpm::Package::from_file(&rpm_path).expect("failed to read RPM");
+    println!("Name:    {}", pkg.name());
+    println!("Version: {}", pkg.version());
+    println!("Release: {}", pkg.release());
+    println!("Arch:    {}", pkg.arch().unwrap_or("(none)"));
+    println!("License: {}", pkg.license());
+    println!("Summary: {}", pkg.summary());
+    println!("NEVRA:   {}", pkg.nevra());
+    println!();
+
+    // Access raw tag data
+    if let Some(data) = pkg.get(librpm::Tag::BUILDTIME) {
+        println!("BUILDTIME tag: {data:?}");
+    }
+}

--- a/examples/signing.rs
+++ b/examples/signing.rs
@@ -1,0 +1,28 @@
+//! Sign an RPM package with a GPG key.
+//!
+//! Usage: cargo run --example signing --features sign -- <package.rpm> <key-id>
+
+use librpm::sign::{self, HashAlgo, SignArgs};
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 3 {
+        eprintln!("Usage: {} <package.rpm> <key-id>", args[0]);
+        std::process::exit(1);
+    }
+    let rpm_path = &args[1];
+    let key_id = &args[2];
+
+    librpm::init().expect("failed to initialize librpm");
+
+    let sign_args = SignArgs::new().key_id(key_id).hash_algo(HashAlgo::SHA256);
+
+    println!("Signing {rpm_path} with key {key_id}...");
+    match sign::sign_package(rpm_path, Some(&sign_args)) {
+        Ok(()) => println!("Signed successfully."),
+        Err(e) => {
+            eprintln!("Signing failed: {e}");
+            std::process::exit(1);
+        }
+    }
+}

--- a/examples/version_comparison.rs
+++ b/examples/version_comparison.rs
@@ -1,0 +1,61 @@
+//! Compare version strings and parse structured EVR values.
+//!
+//! Run with: cargo run --example version_comparison
+
+use std::cmp::Ordering;
+
+fn main() {
+    librpm::init().expect("failed to initialize librpm");
+
+    // Simple string comparison
+    let pairs = [
+        ("1.0", "2.0"),
+        ("1.0.1", "1.0"),
+        ("1.0~rc1", "1.0"),
+        ("1.0^post1", "1.0"),
+        ("2.0", "2.0"),
+    ];
+
+    for (a, b) in pairs {
+        let ord = librpm::version::vercmp(a, b);
+        let symbol = match ord {
+            Ordering::Less => "<",
+            Ordering::Equal => "=",
+            Ordering::Greater => ">",
+        };
+        println!("  {a} {symbol} {b}");
+    }
+    println!();
+
+    // Structured version parsing with epoch support
+    let v1 = librpm::Version::parse("1:3.2.1-5.fc44").unwrap();
+    let v2 = librpm::Version::parse("2.0-1.fc44").unwrap();
+
+    println!(
+        "v1 = {v1} (epoch={}, ver={}, rel={})",
+        v1.epoch().unwrap_or("(none)"),
+        v1.version(),
+        v1.release().unwrap_or("(none)")
+    );
+    println!(
+        "v2 = {v2} (epoch={}, ver={}, rel={})",
+        v2.epoch().unwrap_or("(none)"),
+        v2.version(),
+        v2.release().unwrap_or("(none)")
+    );
+    println!("v1 > v2? {} (epoch wins)", v1 > v2);
+    println!();
+
+    // Sorting a list of versions
+    let mut versions: Vec<librpm::Version> =
+        ["1.0-1.fc44", "1:0.5-1.fc44", "2.0-1.fc44", "1.0-2.fc44"]
+            .iter()
+            .map(|s| librpm::Version::parse(s).unwrap())
+            .collect();
+
+    versions.sort();
+    println!("Sorted versions:");
+    for v in &versions {
+        println!("  {v}");
+    }
+}

--- a/librpmsign-sys/build.rs
+++ b/librpmsign-sys/build.rs
@@ -24,18 +24,15 @@ use std::{env, path::PathBuf};
 fn main() {
     println!("cargo:rustc-link-lib=rpmsign");
 
-    // No functions are consumed from this crate yet.
-    // Uncomment as safe wrappers are added.
     let builder = Builder::default()
         .header("include/librpmsign.hpp")
         // rpmsign.h
-        // .allowlist_function("rpmPkgSign")
-        // .allowlist_function("rpmPkgDelSign")
-        // .allowlist_function("rpmPkgDelFileSign")
+        .allowlist_function("rpmPkgSign")
+        .allowlist_function("rpmPkgDelSign")
+        .allowlist_function("rpmPkgDelFileSign")
         // rpmsign.h — sign args and flags
-        // .allowlist_type("rpmSignArgs")
-        // .allowlist_type("rpmSignFlags_e")
-        .allowlist_function("__librpmsign_sys_placeholder__");
+        .allowlist_type("rpmSignArgs")
+        .allowlist_type("rpmSignFlags_e");
 
     // Write generated bindings to OUT_DIR (to be included in the crate)
     let output_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("binding.rs");
@@ -43,6 +40,26 @@ fn main() {
     builder
         .generate()
         .unwrap()
-        .write_to_file(output_path)
+        .write_to_file(&output_path)
         .unwrap();
+
+    let bindings_src = std::fs::read_to_string(&output_path).unwrap();
+    for line in bindings_src.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("pub const ") {
+            let Some((name, _)) = rest.split_once(':') else {
+                continue;
+            };
+            if let Some(flag) = name.strip_prefix("rpmSignFlags_e_RPMSIGN_FLAG_") {
+                println!("cargo:rpmsignflag_{}=1", flag.to_lowercase());
+            } else if let Some(algo) = name.strip_prefix("pgpHashAlgo_e_PGPHASHALGO_") {
+                println!("cargo:pgphashalgo_{}=1", algo.to_lowercase());
+            }
+        } else if let Some(rest) = trimmed.strip_prefix("pub fn ") {
+            let name = rest.split(&['(', ' '][..]).next().unwrap_or("");
+            if let Some(func) = name.strip_prefix("rpmPkg") {
+                println!("cargo:rpmpkg_{}=1", func.to_lowercase());
+            }
+        }
+    }
 }

--- a/src/internal/header.rs
+++ b/src/internal/header.rs
@@ -68,6 +68,7 @@ impl Header {
         let fd: librpm_sys::FD_t = unsafe { librpm_sys::Fopen(filename.as_ptr(), fmode.as_ptr()) };
         let mut hdr = Header::new();
 
+        #[allow(unused_mut)]
         let mut vsflags = librpm_sys::rpmVSFlags_e_RPMVSF_NOHDRCHK
             | librpm_sys::rpmVSFlags_e_RPMVSF_NOSHA1HEADER
             | librpm_sys::rpmVSFlags_e_RPMVSF_NOSHA256HEADER

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,10 @@ pub mod package;
 /// RPM version parsing and comparison
 pub mod version;
 
+/// RPM package signing (requires the `sign` feature)
+#[cfg(feature = "sign")]
+pub mod sign;
+
 pub use self::{
     db::Db, db::Index, error::Error, macro_context::MacroContext, package::Package,
     version::Version,

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -1,0 +1,234 @@
+/*
+ * Copyright (C) RustRPM Developers
+ *
+ * Licensed under the Mozilla Public License Version 2.0
+ * Fedora-License-Identifier: MPLv2.0
+ * SPDX-2.0-License-Identifier: MPL-2.0
+ * SPDX-3.0-License-Identifier: MPL-2.0
+ *
+ * This is free software.
+ * For more information on the license, see LICENSE.
+ * For more information on free software, see <https://www.gnu.org/philosophy/free-sw.en.html>.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <https://mozilla.org/MPL/2.0/>.
+ */
+
+//! RPM package signing and signature removal
+//!
+//! Requires the `sign` feature and links against `librpmsign.so`.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use librpm::sign::{self, SignArgs, SignFlags};
+//!
+//! librpm::init();
+//!
+//! // Sign with default settings (uses the GPG key configured in RPM macros)
+//! sign::sign_package("/path/to/package.rpm", None).unwrap();
+//!
+//! // Sign with a specific key ID
+//! let args = SignArgs::new().key_id("DEADBEEF");
+//! sign::sign_package("/path/to/package.rpm", Some(&args)).unwrap();
+//! ```
+
+use std::ffi::CString;
+use std::fmt;
+use std::os::unix::ffi::OsStrExt;
+use std::path::Path;
+
+/// Flags controlling signing behaviour.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct SignFlags(u32);
+
+impl SignFlags {
+    /// No special flags.
+    pub const NONE: Self = Self(librpmsign_sys::rpmSignFlags_e_RPMSIGN_FLAG_NONE);
+    /// Include IMA file signatures.
+    pub const IMA: Self = Self(librpmsign_sys::rpmSignFlags_e_RPMSIGN_FLAG_IMA);
+    /// Produce an RPM v3 header+payload signature.
+    #[cfg(has_rpmsignflag_rpmv3)]
+    pub const RPMV3: Self = Self(librpmsign_sys::rpmSignFlags_e_RPMSIGN_FLAG_RPMV3);
+    /// Include fsverity file signatures.
+    #[cfg(has_rpmsignflag_fsverity)]
+    pub const FSVERITY: Self = Self(librpmsign_sys::rpmSignFlags_e_RPMSIGN_FLAG_FSVERITY);
+    /// Re-sign an already-signed package.
+    #[cfg(has_rpmsignflag_resign)]
+    pub const RESIGN: Self = Self(librpmsign_sys::rpmSignFlags_e_RPMSIGN_FLAG_RESIGN);
+    /// Produce an RPM v4 header-only signature.
+    #[cfg(has_rpmsignflag_rpmv4)]
+    pub const RPMV4: Self = Self(librpmsign_sys::rpmSignFlags_e_RPMSIGN_FLAG_RPMV4);
+    /// Produce an RPM v6 signature.
+    #[cfg(has_rpmsignflag_rpmv6)]
+    pub const RPMV6: Self = Self(librpmsign_sys::rpmSignFlags_e_RPMSIGN_FLAG_RPMV6);
+}
+
+impl std::ops::BitOr for SignFlags {
+    type Output = Self;
+    fn bitor(self, rhs: Self) -> Self {
+        Self(self.0 | rhs.0)
+    }
+}
+
+impl std::ops::BitOrAssign for SignFlags {
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.0 |= rhs.0;
+    }
+}
+
+/// Hash algorithm for signing.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct HashAlgo(u32);
+
+impl HashAlgo {
+    /// SHA-1 (legacy, not recommended).
+    pub const SHA1: Self = Self(librpmsign_sys::pgpHashAlgo_e_PGPHASHALGO_SHA1);
+    /// SHA-256.
+    pub const SHA256: Self = Self(librpmsign_sys::pgpHashAlgo_e_PGPHASHALGO_SHA256);
+    /// SHA-384.
+    pub const SHA384: Self = Self(librpmsign_sys::pgpHashAlgo_e_PGPHASHALGO_SHA384);
+    /// SHA-512.
+    pub const SHA512: Self = Self(librpmsign_sys::pgpHashAlgo_e_PGPHASHALGO_SHA512);
+    /// SHA3-256.
+    #[cfg(has_pgphashalgo_sha3_256)]
+    pub const SHA3_256: Self = Self(librpmsign_sys::pgpHashAlgo_e_PGPHASHALGO_SHA3_256);
+    /// SHA3-512.
+    #[cfg(has_pgphashalgo_sha3_512)]
+    pub const SHA3_512: Self = Self(librpmsign_sys::pgpHashAlgo_e_PGPHASHALGO_SHA3_512);
+}
+
+/// Parameters for signing operations.
+///
+/// Use the builder-style methods to configure, then pass to
+/// [`sign_package`], [`del_sign`], or [`del_file_sign`].
+pub struct SignArgs {
+    key_id_c: Option<CString>,
+    hashalgo: u32,
+    signflags: u32,
+}
+
+impl SignArgs {
+    /// Create default signing arguments.
+    pub fn new() -> Self {
+        SignArgs {
+            key_id_c: None,
+            hashalgo: 0,
+            signflags: 0,
+        }
+    }
+
+    /// Set the signer key ID.
+    pub fn key_id(mut self, key_id: &str) -> Self {
+        self.key_id_c = Some(CString::new(key_id).expect("key ID contains NUL byte"));
+        self
+    }
+
+    /// Set the hash algorithm.
+    pub fn hash_algo(mut self, algo: HashAlgo) -> Self {
+        self.hashalgo = algo.0;
+        self
+    }
+
+    /// Set signing flags.
+    pub fn flags(mut self, flags: SignFlags) -> Self {
+        self.signflags = flags.0;
+        self
+    }
+
+    fn to_raw(&self) -> librpmsign_sys::rpmSignArgs {
+        librpmsign_sys::rpmSignArgs {
+            keyid: self
+                .key_id_c
+                .as_ref()
+                .map_or(std::ptr::null_mut(), |c| c.as_ptr().cast_mut()),
+            hashalgo: self.hashalgo,
+            signflags: self.signflags,
+        }
+    }
+}
+
+impl Default for SignArgs {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Error returned by signing operations.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SignError;
+
+impl fmt::Display for SignError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "RPM signing operation failed")
+    }
+}
+
+impl std::error::Error for SignError {}
+
+/// Sign an RPM package.
+///
+/// Pass `None` for `args` to use default settings (key and algorithm
+/// are taken from RPM macro configuration).
+///
+/// # Panics
+///
+/// Panics if `path` contains interior NUL bytes.
+pub fn sign_package(path: impl AsRef<Path>, args: Option<&SignArgs>) -> Result<(), SignError> {
+    let path_c =
+        CString::new(path.as_ref().as_os_str().as_bytes()).expect("path contains NUL byte");
+    let raw_args;
+    let args_ptr = match args {
+        Some(a) => {
+            raw_args = a.to_raw();
+            &raw_args
+        }
+        None => std::ptr::null(),
+    };
+    let rc = unsafe { librpmsign_sys::rpmPkgSign(path_c.as_ptr(), args_ptr) };
+    if rc == 0 { Ok(()) } else { Err(SignError) }
+}
+
+/// Delete signature(s) from an RPM package.
+///
+/// # Panics
+///
+/// Panics if `path` contains interior NUL bytes.
+pub fn del_sign(path: impl AsRef<Path>, args: Option<&SignArgs>) -> Result<(), SignError> {
+    let path_c =
+        CString::new(path.as_ref().as_os_str().as_bytes()).expect("path contains NUL byte");
+    let raw_args;
+    let args_ptr = match args {
+        Some(a) => {
+            raw_args = a.to_raw();
+            &raw_args
+        }
+        None => std::ptr::null(),
+    };
+    let rc = unsafe { librpmsign_sys::rpmPkgDelSign(path_c.as_ptr(), args_ptr) };
+    if rc == 0 { Ok(()) } else { Err(SignError) }
+}
+
+/// Delete file signature(s) from an RPM package.
+///
+/// # Panics
+///
+/// Panics if `path` contains interior NUL bytes.
+#[cfg(has_rpmpkg_delfilesign)]
+pub fn del_file_sign(path: impl AsRef<Path>, args: Option<&SignArgs>) -> Result<(), SignError> {
+    let path_c =
+        CString::new(path.as_ref().as_os_str().as_bytes()).expect("path contains NUL byte");
+    let raw_args;
+    let args_ptr = match args {
+        Some(a) => {
+            raw_args = a.to_raw();
+            &raw_args
+        }
+        None => std::ptr::null(),
+    };
+    let rc = unsafe { librpmsign_sys::rpmPkgDelFileSign(path_c.as_ptr(), args_ptr) };
+    if rc == 0 { Ok(()) } else { Err(SignError) }
+}

--- a/tests/sign.rs
+++ b/tests/sign.rs
@@ -1,0 +1,73 @@
+//! Tests for the signing module (requires the `sign` feature).
+//!
+//! These tests only verify the API surface compiles and that error paths
+//! work correctly. Actually signing requires GPG keys, so we test that
+//! signing a nonexistent file returns an error rather than panicking.
+
+#![cfg(feature = "sign")]
+
+use librpm::sign::{self, HashAlgo, SignArgs, SignError, SignFlags};
+
+mod common;
+
+// SignFlags
+
+#[test]
+fn test_sign_flags_default() {
+    assert_eq!(SignFlags::default(), SignFlags::NONE);
+}
+
+// SignArgs builder
+
+#[test]
+fn test_sign_args_default() {
+    let _args = SignArgs::default();
+}
+
+#[test]
+fn test_sign_args_builder() {
+    let _args = SignArgs::new()
+        .key_id("DEADBEEF")
+        .hash_algo(HashAlgo::SHA256)
+        .flags(SignFlags::IMA);
+}
+
+// Error paths — operations on nonexistent files
+
+#[test]
+fn test_sign_nonexistent_file() {
+    common::configure();
+    let result = sign::sign_package("/nonexistent/package.rpm", None);
+    assert_eq!(result, Err(SignError));
+}
+
+#[test]
+fn test_del_sign_nonexistent_file() {
+    common::configure();
+    let result = sign::del_sign("/nonexistent/package.rpm", None);
+    assert_eq!(result, Err(SignError));
+}
+
+#[test]
+#[cfg(has_rpmpkg_delfilesign)]
+fn test_del_file_sign_nonexistent_file() {
+    common::configure();
+    let result = sign::del_file_sign("/nonexistent/package.rpm", None);
+    assert_eq!(result, Err(SignError));
+}
+
+// SignError Display
+
+#[test]
+fn test_sign_error_display() {
+    let err = SignError;
+    assert_eq!(format!("{err}"), "RPM signing operation failed");
+}
+
+// HashAlgo constants exist
+
+#[test]
+fn test_hash_algo_constants() {
+    assert_ne!(HashAlgo::SHA256, HashAlgo::SHA512);
+    assert_ne!(HashAlgo::SHA256, HashAlgo::SHA1);
+}


### PR DESCRIPTION
Wrap librpmsign's API behind an optional `sign` feature:
- sign_package(), del_sign(), del_file_sign() for signing operations
- SignArgs builder for key ID, hash algorithm, and flag configuration
- SignFlags and HashAlgo newtypes for type-safe flag handling

Also remove duplicate tests/test-build.rs (renamed to build.rs in previous commit).

Assisted-By: Claude Opus 4.6