### PR TITLE
Wrap librpm logging functionality and integrate with 'log' crate

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* `logging::set_verbosity()` controls librpm's log verbosity at the C level
+  and `logging::last_message()` retrieves the most recent librpm log message.
+  A `LogLevel` enum provides the available verbosity levels.
+* `logging::set_behavior()` switches between routing log messages through
+  Rust's `log` crate (`LogBehavior::LogCrate`, the default) or librpm's
+  native stderr output (`LogBehavior::Default`).
+* When `LogBehavior::LogCrate` mode is set, you can install any
+  `log`-compatible backend (e.g. `env_logger`) and messages appear
+  automatically with the target `"librpm"`.
 * `Db::init_db()`, `Db::rebuild()`, and `Db::verify()` for RPM database
   management — equivalent to `rpm --initdb`, `rpm --rebuilddb`, and
   `rpmdb --verifydb` respectively.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,12 +12,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -28,8 +78,14 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 2.0.118",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -64,10 +120,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "env_filter"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
 
 [[package]]
 name = "errno"
@@ -103,12 +219,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
+]
+
+[[package]]
+name = "jiff"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e184d09547b80eb7e20d141ba2fb1fbac843ca53f4cf1b31210adc4c1adc6e16"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323da076b7a6faf914dc677cb05a4b907742ff7375c8322c9e7f5061e5e0e9de"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -131,9 +289,11 @@ dependencies = [
 name = "librpm"
 version = "0.2.1"
 dependencies = [
+ "env_logger",
  "librpm-sys",
  "librpmbuild-sys",
  "librpmsign-sys",
+ "log",
  "streaming-iterator",
  "tempfile",
 ]
@@ -200,13 +360,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "portable-atomic"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -274,11 +455,31 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
  "windows-sys",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -305,6 +506,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,10 +530,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ rust-version.workspace = true
 librpm-sys = { workspace = true }
 librpmbuild-sys = { workspace = true, optional = true }
 librpmsign-sys = { workspace = true, optional = true }
+log = "0.4"
 streaming-iterator = "0.1.5"
 
 [features]
@@ -46,6 +47,7 @@ sign = ["dep:librpmsign-sys"]
 default = ["sign"]
 
 [dev-dependencies]
+env_logger = "0.11"
 tempfile = "3"
 
 [lints.rust]

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ RHEL 8 support may be added in the future, but is not a current priority.
 - [x] RPM reader API (i.e. for `.rpm` files)
 - [ ] RPM builder API (i.e. `librpmbuild`)
 - [x] RPM signing API (i.e. `librpmsign`)
+- [x] Logging integration with Rust's `log` crate
 
 ## License
 

--- a/examples/logging.rs
+++ b/examples/logging.rs
@@ -1,0 +1,23 @@
+//! Demonstrate librpm log messages routed through Rust's `log` crate.
+//!
+//! Run with: RUST_LOG=librpm=debug cargo run --example logging
+
+use librpm::logging::{self, LogBehavior, LogLevel};
+
+fn main() {
+    env_logger::init();
+
+    librpm::init().expect("failed to initialize librpm");
+
+    // Route librpm messages through Rust's log crate instead of stderr
+    logging::set_behavior(LogBehavior::LogCrate);
+    log::info!("librpm logging routed through log crate");
+
+    // Restrict librpm to only emit warnings and above
+    logging::set_verbosity(LogLevel::Warning);
+
+    // Retrieve the last log message from librpm (if any)
+    if let Some(msg) = logging::last_message() {
+        log::info!("last librpm message: {msg}");
+    }
+}

--- a/librpm-sys/build.rs
+++ b/librpm-sys/build.rs
@@ -337,8 +337,11 @@ fn main() {
         // .allowlist_function("rpmpsFreeIterator")
         // .allowlist_function("rpmpsiNext")
         // rpmlog.h — logging
-        // .allowlist_function("rpmlog")
-        // .allowlist_function("rpmlogSetFile")
+        .allowlist_function("rpmlogSetCallback")
+        .allowlist_function("rpmlogRecMessage")
+        .allowlist_function("rpmlogRecPriority")
+        .allowlist_function("rpmlogSetMask")
+        .allowlist_function("rpmlogMessage")
         // rpmarchive.h — cpio archive read/write
         // .allowlist_function("rpmfiNewArchiveWriter")
         // .allowlist_function("rpmfiNewArchiveReader")
@@ -402,7 +405,7 @@ fn main() {
         // rpmprob.h — problem type
         // .allowlist_type("rpmProblemType_e")
         // rpmlog.h — log level
-        // .allowlist_type("rpmlogLvl_e")
+        .allowlist_type("rpmlogLvl_e")
         // rpmcrypto.h — digest algorithm
         // .allowlist_type("rpmHashAlgo_e")
         // librpm.hpp (local workaround)

--- a/librpm-sys/include/librpm.hpp
+++ b/librpm-sys/include/librpm.hpp
@@ -42,6 +42,7 @@
 /** RPM sub-system header files (from Table 16-1, omitting popt.h) */
 #include <rpm/rpmdb.h> // RPM database access
 #include <rpm/rpmio.h> // RPM input/output routines
+#include <rpm/rpmlog.h> // RPM logging
 
 /** RPM data object header files (from Table 16-2) */
 #include <rpm/header.h> // Package headers

--- a/src/config.rs
+++ b/src/config.rs
@@ -77,7 +77,6 @@ pub(crate) fn read_file(config_file: Option<&Path>) -> Result<(), Error> {
             ),
         }
     }
-
     global_state.configured = true;
 
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,14 @@
 //! the library, then obtain a [`Db`] handle via [`Db::open`] to query the
 //! RPM database.
 //!
+//! ## Logging
+//!
+//! By default, librpm logs to stderr using its native logging. Call
+//! [`logging::set_behavior`] with [`LogBehavior::LogCrate`] to route
+//! messages through Rust's [`log`] crate instead. Messages are emitted
+//! with the target `"librpm"`.
+//!
+//! [`log`]: https://docs.rs/log
 //! [librpm-sys]: https://rustrpm.org/librpm_sys/index.html
 
 #![doc(html_root_url = "https://rustrpm.org/librpm/")]
@@ -38,6 +46,9 @@ pub mod error;
 
 /// RPM configuration (i.e. rpmrc)
 mod config;
+
+/// Logging bridge: routes librpm's C log output through Rust's `log` facade
+pub mod logging;
 
 /// Changelog information for RPM packages
 pub mod changelog;
@@ -70,7 +81,8 @@ pub mod sign;
 pub use self::{
     changelog::ChangelogEntry, db::Db, db::Index, db::MatchMode, dep::DepFlags, dep::Dependencies,
     dep::Dependency, error::Error, files::FileAttrs, files::FileEntry, files::Files,
-    macro_context::MacroContext, package::Package, version::Version,
+    logging::LogBehavior, logging::LogLevel, macro_context::MacroContext, package::Package,
+    version::Version,
 };
 
 // Re-export types used in public API

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,187 @@
+/*
+ * Copyright (C) RustRPM Developers
+ *
+ * Licensed under the Mozilla Public License Version 2.0
+ * Fedora-License-Identifier: MPLv2.0
+ * SPDX-2.0-License-Identifier: MPL-2.0
+ * SPDX-3.0-License-Identifier: MPL-2.0
+ *
+ * This is free software.
+ * For more information on the license, see LICENSE.
+ * For more information on free software, see <https://www.gnu.org/philosophy/free-sw.en.html>.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <https://mozilla.org/MPL/2.0/>.
+ */
+
+//! Bridge between librpm's C logging system and Rust's `log` crate.
+//!
+//! By default, librpm logs to stderr using its native logging. Call
+//! [`set_behavior`] with [`LogBehavior::LogCrate`] to route messages
+//! through Rust's [`log`] facade instead.
+//!
+//! This module also provides [`set_verbosity`] and [`last_message`]
+//! for direct access to librpm's log state.
+
+use std::ffi::CStr;
+use std::ptr;
+
+/// librpm log verbosity levels.
+///
+/// These correspond to the `rpmlogLvl_e` values in `rpmlog.h` and control
+/// which messages librpm will emit. Use with [`set_verbosity`] to set the
+/// maximum verbosity level.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[repr(u32)]
+pub enum LogLevel {
+    /// System is unusable
+    Emergency = librpm_sys::rpmlogLvl_e_RPMLOG_EMERG,
+    /// Action must be taken immediately
+    Alert = librpm_sys::rpmlogLvl_e_RPMLOG_ALERT,
+    /// Critical conditions
+    Critical = librpm_sys::rpmlogLvl_e_RPMLOG_CRIT,
+    /// Error conditions
+    Error = librpm_sys::rpmlogLvl_e_RPMLOG_ERR,
+    /// Warning conditions
+    Warning = librpm_sys::rpmlogLvl_e_RPMLOG_WARNING,
+    /// Normal but significant condition
+    Notice = librpm_sys::rpmlogLvl_e_RPMLOG_NOTICE,
+    /// Informational
+    Info = librpm_sys::rpmlogLvl_e_RPMLOG_INFO,
+    /// Debug-level messages
+    Debug = librpm_sys::rpmlogLvl_e_RPMLOG_DEBUG,
+}
+
+/// Controls how librpm log messages are dispatched.
+///
+/// Use with [`set_behavior`] to change the logging behavior.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum LogBehavior {
+    /// Route messages through Rust's `log` crate.
+    /// librpm's default stderr output is suppressed.
+    LogCrate,
+
+    /// Use librpm's native logging (stderr). This is the default.
+    Default,
+}
+
+#[allow(non_upper_case_globals)]
+fn to_log_level(pri: librpm_sys::rpmlogLvl_e) -> log::Level {
+    match pri {
+        librpm_sys::rpmlogLvl_e_RPMLOG_EMERG
+        | librpm_sys::rpmlogLvl_e_RPMLOG_ALERT
+        | librpm_sys::rpmlogLvl_e_RPMLOG_CRIT
+        | librpm_sys::rpmlogLvl_e_RPMLOG_ERR => log::Level::Error,
+        librpm_sys::rpmlogLvl_e_RPMLOG_WARNING => log::Level::Warn,
+        librpm_sys::rpmlogLvl_e_RPMLOG_NOTICE | librpm_sys::rpmlogLvl_e_RPMLOG_INFO => {
+            log::Level::Info
+        }
+        librpm_sys::rpmlogLvl_e_RPMLOG_DEBUG => log::Level::Debug,
+        _ => log::Level::Trace,
+    }
+}
+
+unsafe extern "C" fn rpm_log_callback(
+    rec: librpm_sys::rpmlogRec,
+    _data: librpm_sys::rpmlogCallbackData,
+) -> std::os::raw::c_int {
+    let pri = unsafe { librpm_sys::rpmlogRecPriority(rec) };
+    let msg_ptr = unsafe { librpm_sys::rpmlogRecMessage(rec) };
+
+    if !msg_ptr.is_null() {
+        let level = to_log_level(pri);
+        let msg = unsafe { CStr::from_ptr(msg_ptr) }.to_string_lossy();
+        let msg = msg.trim_end();
+        log::log!(target: "librpm", level, "{}", msg);
+    }
+
+    0
+}
+
+/// Set the maximum verbosity level for librpm's internal logging.
+///
+/// Messages at `level` and above (more severe) will be emitted; messages
+/// below `level` are suppressed at the C level before reaching either
+/// the `log` callback or librpm's default output.
+///
+/// # Example
+///
+/// ```no_run
+/// librpm::init().unwrap();
+/// // Only emit warnings and errors from librpm
+/// librpm::logging::set_verbosity(librpm::logging::LogLevel::Warning);
+/// ```
+pub fn set_verbosity(level: LogLevel) {
+    // RPMLOG_UPTO(pri) = (1 << (pri + 1)) - 1
+    let mask = (1i32 << (level as u32 + 1)) - 1;
+    unsafe {
+        librpm_sys::rpmlogSetMask(mask);
+    }
+}
+
+/// Set the logging behavior.
+///
+/// Controls whether librpm log messages are forwarded through Rust's `log`
+/// crate or sent to librpm's default output (typically stderr).
+///
+/// This also adjusts the log mask: [`LogBehavior::LogCrate`] passes all
+/// levels through (letting the Rust `log` framework filter), while
+/// [`LogBehavior::Default`] restores librpm's default mask (notice and
+/// above). A subsequent call to [`set_verbosity`] overrides either default.
+///
+/// The initial behavior is [`LogBehavior::Default`].
+///
+/// # Example
+///
+/// ```no_run
+/// librpm::init().unwrap();
+/// // Route librpm messages through Rust's log crate
+/// librpm::logging::set_behavior(librpm::logging::LogBehavior::LogCrate);
+/// ```
+pub fn set_behavior(behavior: LogBehavior) {
+    unsafe {
+        match behavior {
+            LogBehavior::LogCrate => {
+                // Pass all levels through; let the Rust log framework filter
+                librpm_sys::rpmlogSetMask(
+                    ((1u32 << (librpm_sys::rpmlogLvl_e_RPMLOG_DEBUG + 1)) - 1) as i32,
+                );
+                librpm_sys::rpmlogSetCallback(Some(rpm_log_callback), ptr::null_mut());
+            }
+            LogBehavior::Default => {
+                librpm_sys::rpmlogSetCallback(None, ptr::null_mut());
+                // Restore librpm's default: RPMLOG_UPTO(RPMLOG_NOTICE)
+                librpm_sys::rpmlogSetMask(
+                    ((1u32 << (librpm_sys::rpmlogLvl_e_RPMLOG_NOTICE + 1)) - 1) as i32,
+                );
+            }
+        }
+    }
+}
+
+/// Return the text of the last librpm log message, if any.
+///
+/// This is useful for retrieving details after an operation fails, since
+/// some librpm errors only report specifics through the log system rather
+/// than through return codes.
+///
+/// # Example
+///
+/// ```no_run
+/// librpm::init().unwrap();
+/// if let Some(msg) = librpm::logging::last_message() {
+///     eprintln!("last librpm message: {msg}");
+/// }
+/// ```
+pub fn last_message() -> Option<String> {
+    let ptr = unsafe { librpm_sys::rpmlogMessage() };
+    if ptr.is_null() {
+        return None;
+    }
+    let msg = unsafe { CStr::from_ptr(ptr) }
+        .to_string_lossy()
+        .trim_end()
+        .to_string();
+    if msg.is_empty() { None } else { Some(msg) }
+}


### PR DESCRIPTION
Add public logging API: set_verbosity, last_message, set_behavior

Expose direct wrappers for rpmlogSetMask and rpmlogMessage so users can control librpm's verbosity at the C level and retrieve the last log message for better error diagnostics. Adds a LogLevel enum mapping the rpmlogLvl_e values.

By default, librpm uses its native stderr logging. Calling set_behavior(LogBehavior::LogCrate) installs a C callback via rpmlogSetCallback that intercepts all librpm log messages, maps rpmlog levels to log::Level, and forwards them through the log facade with target "librpm".

Assisted-By: Claude Opus 4.6