### PR TITLE
Add archive extraction API for reading RPM payload contents

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,25 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+* **Breaking**: `Package` renamed to `PackageHeader.
+
 ### Added
 
-* `logging::set_verbosity()` controls librpm's log verbosity at the C level
-  and `logging::last_message()` retrieves the most recent librpm log message.
-  A `LogLevel` enum provides the available verbosity levels.
-* `logging::set_behavior()` switches between routing log messages through
-  Rust's `log` crate (`LogBehavior::LogCrate`, the default) or librpm's
-  native stderr output (`LogBehavior::Default`).
-* When `LogBehavior::LogCrate` mode is set, you can install any
-  `log`-compatible backend (e.g. `env_logger`) and messages appear
-  automatically with the target `"librpm"`.
-* `Db::init_db()`, `Db::rebuild()`, and `Db::verify()` for RPM database
-  management — equivalent to `rpm --initdb`, `rpm --rebuilddb`, and
-  `rpmdb --verifydb` respectively.
-* `Package::changelogs()` returns changelog entries as `Vec<ChangelogEntry>`,
-  built from the parallel CHANGELOGTIME / CHANGELOGNAME / CHANGELOGTEXT header
-  arrays. Each `ChangelogEntry` provides `time()`, `timestamp()`, `name()`,
-  and `text()` accessors.
-* `Package::format()` applies an RPM query format string to a package header using
+* `PackageHeader::format()` applies an RPM query format string to a package header using
   `%{TAG}` syntax, equivalent to `rpm --queryformat` or librpm's `headerFormat()`.
 * `Index` enum expanded with `Basenames`, `Dirnames`, `Instfilenames`,
   `Providename`, `Requirename`, `Conflictname`, `Obsoletename`, `Group`,
@@ -36,6 +24,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `Iter::match_count()` and `Iter::offset()` expose the iterator's index
   snapshot count and current record offset (`rpmdbGetIteratorCount`,
   `rpmdbGetIteratorOffset`)
+* `Db::init_db()`, `Db::rebuild()`, and `Db::verify()` for RPM database
+  management — equivalent to `rpm --initdb`, `rpm --rebuilddb`, and
+  `rpmdb --verifydb` respectively.
+* `archive::PackageReader` provides sequential, streaming access to the file
+  contents inside an `.rpm` package's payload.
+* `PackageHeader::changelogs()` returns changelog entries as `Vec<ChangelogEntry>`.
+  Each `ChangelogEntry` provides `time()`, `timestamp()`, `name()`, and `text()` accessors.
+* `logging::set_verbosity()` controls librpm's log verbosity at the C level
+  and `logging::last_message()` retrieves the most recent librpm log message.
+  A `LogLevel` enum provides the available verbosity levels.
+* `logging::set_behavior()` switches between routing log messages through
+  Rust's `log` crate (`LogBehavior::LogCrate`, the default) or librpm's
+  native stderr output (`LogBehavior::Default`).
+* When `LogBehavior::LogCrate` mode is set, you can install any
+  `log`-compatible backend (e.g. `env_logger`) and messages appear
+  automatically with the target `"librpm"`.
 
 ### Fixed
 

--- a/examples/archive_extraction.rs
+++ b/examples/archive_extraction.rs
@@ -1,0 +1,42 @@
+use std::io::Read;
+use std::path::Path;
+
+use librpm::archive::PackageReader;
+
+fn main() {
+    let path = std::env::args()
+        .nth(1)
+        .expect("Usage: archive_extraction <path-to-rpm>");
+
+    librpm::init().unwrap();
+
+    let mut archive = PackageReader::open(Path::new(&path)).unwrap();
+
+    println!("Package: {}", archive.package().nevra());
+    println!();
+
+    let mut total_bytes: u64 = 0;
+    let mut file_count: usize = 0;
+
+    while let Some(mut entry) = archive.next_entry().unwrap() {
+        let content_marker = if entry.has_content() { " " } else { "*" };
+        println!(
+            "{}{:>10}  {:o}  {}",
+            content_marker,
+            entry.size(),
+            entry.mode(),
+            entry.path(),
+        );
+
+        if entry.has_content() {
+            let mut buf = Vec::new();
+            entry.read_to_end(&mut buf).unwrap();
+            total_bytes += buf.len() as u64;
+        }
+
+        file_count += 1;
+    }
+
+    println!();
+    println!("{file_count} files, {total_bytes} bytes of content extracted");
+}

--- a/examples/package_reading.rs
+++ b/examples/package_reading.rs
@@ -10,7 +10,7 @@ fn main() {
     let rpm_path = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("testdata/rpms/rpm-basic-with-rsa4096-2.3.4-5.el9.noarch.rpm");
 
-    let pkg = librpm::Package::from_file(&rpm_path).expect("failed to read RPM");
+    let pkg = librpm::PackageHeader::from_file(&rpm_path).expect("failed to read RPM");
     println!("Name:    {}", pkg.name());
     println!("Version: {}", pkg.version());
     println!("Release: {}", pkg.release());

--- a/librpm-sys/build.rs
+++ b/librpm-sys/build.rs
@@ -117,8 +117,8 @@ fn main() {
         // .allowlist_function("rpmdsIsRich")
         // rpmfi.h — file info (legacy iterator-style API; Python
         // only uses rpmfiFree/rpmfiNext for archive iteration)
-        // .allowlist_function("rpmfiFree")
-        // .allowlist_function("rpmfiNext")
+        .allowlist_function("rpmfiFree")
+        .allowlist_function("rpmfiNext")
         // rpmio.h — I/O routines
         .allowlist_function("Fopen")
         .allowlist_function("Fclose")
@@ -344,15 +344,15 @@ fn main() {
         .allowlist_function("rpmlogMessage")
         // rpmarchive.h — cpio archive read/write
         // .allowlist_function("rpmfiNewArchiveWriter")
-        // .allowlist_function("rpmfiNewArchiveReader")
-        // .allowlist_function("rpmfiArchiveClose")
+        .allowlist_function("rpmfiNewArchiveReader")
+        .allowlist_function("rpmfiArchiveClose")
         // .allowlist_function("rpmfiArchiveTell")
         // .allowlist_function("rpmfiArchiveWrite")
         // .allowlist_function("rpmfiArchiveWriteFile")
-        // .allowlist_function("rpmfiArchiveRead")
-        // .allowlist_function("rpmfiArchiveHasContent")
-        // .allowlist_function("rpmfiArchiveReadToFile")
-        // .allowlist_function("rpmfileStrerror")
+        .allowlist_function("rpmfiArchiveRead")
+        .allowlist_function("rpmfiArchiveHasContent")
+        .allowlist_function("rpmfiArchiveReadToFile")
+        .allowlist_function("rpmfileStrerror")
         // rpmstrpool.h — string interning pool
         // .allowlist_function("rpmstrPoolCreate")
         // .allowlist_function("rpmstrPoolFree")
@@ -397,8 +397,9 @@ fn main() {
         // ----------------------------------------------------------
         // Headers not yet included in librpm.hpp
         // ----------------------------------------------------------
-        // rpmfiles.h — file type and state
+        // rpmfiles.h — file type, state, and iteration mode
         .allowlist_type("rpmfileAttrs_e")
+        .allowlist_type("rpmFileIter_e")
         // .allowlist_type("rpmfileState_e")
         // rpmkeyring.h
         // .allowlist_type("rpmKeyringModifyMode_e")

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -1,0 +1,309 @@
+/*
+ * Copyright (C) RustRPM Developers
+ *
+ * Licensed under the Mozilla Public License Version 2.0
+ * Fedora-License-Identifier: MPLv2.0
+ * SPDX-2.0-License-Identifier: MPL-2.0
+ * SPDX-3.0-License-Identifier: MPL-2.0
+ *
+ * This is free software.
+ * For more information on the license, see LICENSE.
+ * For more information on free software, see <https://www.gnu.org/philosophy/free-sw.en.html>.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <https://mozilla.org/MPL/2.0/>.
+ */
+
+//! Archive (payload) extraction for RPM packages
+//!
+//! Provides sequential, streaming access to the file contents inside an
+//! `.rpm` package. Each entry in the archive can be read via [`std::io::Read`].
+//!
+//! ```no_run
+//! use librpm::archive::PackageReader;
+//! use std::io::Read;
+//! use std::path::Path;
+//!
+//! let mut pkg = PackageReader::open(Path::new("package.rpm")).unwrap();
+//!
+//! while let Some(mut entry) = pkg.next_entry().unwrap() {
+//!     println!("{}: {} bytes", entry.path(), entry.size());
+//!     if entry.has_content() {
+//!         let mut buf = Vec::new();
+//!         entry.read_to_end(&mut buf).unwrap();
+//!     }
+//! }
+//! ```
+
+use std::ffi::CStr;
+use std::io;
+use std::marker::PhantomData;
+use std::path::Path;
+use std::ptr::NonNull;
+
+use crate::error::ErrorKind;
+use crate::files::{FileAttrs, Files};
+use crate::internal::header::Header;
+use crate::package::PackageHeader;
+
+unsafe extern "C" {
+    fn free(ptr: *mut std::ffi::c_void);
+}
+
+/// RAII wrapper around librpm's `FD_t` file descriptor.
+struct Fd(librpm_sys::FD_t);
+
+impl Drop for Fd {
+    fn drop(&mut self) {
+        unsafe {
+            librpm_sys::Fclose(self.0);
+        }
+    }
+}
+
+/// An RPM package archive reader.
+///
+/// Provides sequential access to the files inside an RPM package's payload.
+/// Entries are visited in the order they appear in the archive; random access
+/// is not supported.
+///
+/// Use [`next_entry`](PackageArchive::next_entry) to advance through the archive.
+/// Each [`ArchiveEntry`] borrows the archive mutably, so the compiler enforces
+/// the constraint that you must finish with one entry before advancing to the
+/// next.
+pub struct PackageReader {
+    fi: NonNull<librpm_sys::rpmfi_s>,
+    _fd: Fd,
+    files: Files,
+    header: PackageHeader,
+    exhausted: bool,
+}
+
+impl PackageReader {
+    /// Open an `.rpm` file for archive extraction.
+    ///
+    /// Reads the package header and prepares the payload for sequential
+    /// iteration. The file remains open until the `PackageReader` is dropped.
+    pub fn open(path: &Path) -> Result<Self, crate::error::Error> {
+        let (hdr, raw_fd) = Header::read_package_file(path)
+            .map_err(|e| crate::error::Error::new(ErrorKind::Archive, Some(format!("{e:?}"))))?;
+
+        let fd = Fd(raw_fd);
+        let files = Files::from_header(&hdr);
+        let header = PackageHeader::from_header(&hdr);
+
+        let fi = unsafe {
+            librpm_sys::rpmfiNewArchiveReader(
+                fd.0,
+                files.as_ptr(),
+                librpm_sys::rpmFileIter_e_RPMFI_ITER_READ_ARCHIVE as i32,
+            )
+        };
+
+        let fi = NonNull::new(fi).ok_or_else(|| {
+            crate::error::Error::new(
+                ErrorKind::Archive,
+                Some("failed to create archive reader".to_string()),
+            )
+        })?;
+
+        Ok(PackageReader {
+            fi,
+            _fd: fd,
+            files,
+            header,
+            exhausted: false,
+        })
+    }
+
+    /// Advance to the next entry in the archive.
+    ///
+    /// Returns `Ok(None)` when all entries have been visited. The returned
+    /// [`ArchiveEntry`] borrows this archive mutably, so you must drop it
+    /// (or let it go out of scope) before calling `next_entry` again.
+    pub fn next_entry(&mut self) -> Result<Option<ArchiveEntry<'_>>, crate::error::Error> {
+        if self.exhausted {
+            return Ok(None);
+        }
+
+        let ix = unsafe { librpm_sys::rpmfiNext(self.fi.as_ptr()) };
+
+        if ix < 0 {
+            self.exhausted = true;
+            return Ok(None);
+        }
+
+        Ok(Some(ArchiveEntry {
+            fi: self.fi,
+            files: &self.files,
+            index: ix,
+            _marker: PhantomData,
+        }))
+    }
+
+    /// Access the package metadata (name, version, dependencies, etc.).
+    pub fn package(&self) -> &PackageHeader {
+        &self.header
+    }
+}
+
+impl Drop for PackageReader {
+    fn drop(&mut self) {
+        unsafe {
+            librpm_sys::rpmfiArchiveClose(self.fi.as_ptr());
+            librpm_sys::rpmfiFree(self.fi.as_ptr());
+        }
+    }
+}
+
+/// A single entry in an RPM archive.
+///
+/// Provides metadata about the current file and, for regular files,
+/// streaming access to its content via [`std::io::Read`].
+///
+/// This type borrows the parent [`PackageReader`] mutably, which enforces
+/// sequential access at compile time.
+pub struct ArchiveEntry<'a> {
+    fi: NonNull<librpm_sys::rpmfi_s>,
+    files: &'a Files,
+    index: i32,
+    _marker: PhantomData<&'a mut PackageReader>,
+}
+
+impl ArchiveEntry<'_> {
+    /// Full path of the file.
+    pub fn path(&self) -> String {
+        let p = unsafe { librpm_sys::rpmfilesFN(self.files.as_ptr(), self.index) };
+        assert!(!p.is_null());
+        let s = unsafe { CStr::from_ptr(p) }
+            .to_str()
+            .expect("file path is not UTF-8")
+            .to_owned();
+        unsafe { free(p.cast()) };
+        s
+    }
+
+    /// Base name of the file (filename without directory).
+    pub fn basename(&self) -> &str {
+        let p = unsafe { librpm_sys::rpmfilesBN(self.files.as_ptr(), self.index) };
+        assert!(!p.is_null());
+        unsafe { CStr::from_ptr(p) }
+            .to_str()
+            .expect("file basename is not UTF-8")
+    }
+
+    /// Directory name of the file (including trailing slash).
+    pub fn dirname(&self) -> &str {
+        let di = unsafe { librpm_sys::rpmfilesDI(self.files.as_ptr(), self.index) };
+        let p = unsafe { librpm_sys::rpmfilesDN(self.files.as_ptr(), di as i32) };
+        assert!(!p.is_null());
+        unsafe { CStr::from_ptr(p) }
+            .to_str()
+            .expect("file dirname is not UTF-8")
+    }
+
+    /// File size in bytes.
+    pub fn size(&self) -> u64 {
+        unsafe { librpm_sys::rpmfilesFSize(self.files.as_ptr(), self.index) }
+    }
+
+    /// File mode (Unix permission bits and file type).
+    pub fn mode(&self) -> u16 {
+        unsafe { librpm_sys::rpmfilesFMode(self.files.as_ptr(), self.index) }
+    }
+
+    /// Owner (user name) of the file.
+    pub fn user(&self) -> &str {
+        let p = unsafe { librpm_sys::rpmfilesFUser(self.files.as_ptr(), self.index) };
+        assert!(!p.is_null());
+        unsafe { CStr::from_ptr(p) }
+            .to_str()
+            .expect("file user is not UTF-8")
+    }
+
+    /// Group of the file.
+    pub fn group(&self) -> &str {
+        let p = unsafe { librpm_sys::rpmfilesFGroup(self.files.as_ptr(), self.index) };
+        assert!(!p.is_null());
+        unsafe { CStr::from_ptr(p) }
+            .to_str()
+            .expect("file group is not UTF-8")
+    }
+
+    /// File attribute flags (config, doc, ghost, license, etc.).
+    pub fn flags(&self) -> FileAttrs {
+        let raw = unsafe { librpm_sys::rpmfilesFFlags(self.files.as_ptr(), self.index) };
+        FileAttrs::from_raw(raw)
+    }
+
+    /// Symlink target, or `None` if this is not a symbolic link.
+    pub fn link_target(&self) -> Option<&str> {
+        let p = unsafe { librpm_sys::rpmfilesFLink(self.files.as_ptr(), self.index) };
+        if p.is_null() {
+            return None;
+        }
+        let s = unsafe { CStr::from_ptr(p) }
+            .to_str()
+            .expect("link target is not UTF-8");
+        if s.is_empty() { None } else { Some(s) }
+    }
+
+    /// File capabilities string, or `None` if no capabilities are set.
+    pub fn caps(&self) -> Option<&str> {
+        let p = unsafe { librpm_sys::rpmfilesFCaps(self.files.as_ptr(), self.index) };
+        if p.is_null() {
+            return None;
+        }
+        let s = unsafe { CStr::from_ptr(p) }
+            .to_str()
+            .expect("file caps is not UTF-8");
+        if s.is_empty() { None } else { Some(s) }
+    }
+
+    /// Binary digest of the file, or `None` if no digest is available.
+    pub fn digest(&self) -> Option<&[u8]> {
+        let mut algo: std::ffi::c_int = 0;
+        let mut len: usize = 0;
+        let p = unsafe {
+            librpm_sys::rpmfilesFDigest(self.files.as_ptr(), self.index, &mut algo, &mut len)
+        };
+        if p.is_null() || len == 0 {
+            None
+        } else {
+            Some(unsafe { std::slice::from_raw_parts(p, len) })
+        }
+    }
+
+    /// Whether this entry has file content stored in the archive.
+    ///
+    /// Returns `true` for regular files and `false` for hardlinks whose
+    /// content appears under a different entry, as well as directories,
+    /// symlinks, and other non-regular file types.
+    pub fn has_content(&self) -> bool {
+        unsafe { librpm_sys::rpmfiArchiveHasContent(self.fi.as_ptr()) == 1 }
+    }
+}
+
+impl io::Read for ArchiveEntry<'_> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let n = unsafe {
+            librpm_sys::rpmfiArchiveRead(self.fi.as_ptr(), buf.as_mut_ptr().cast(), buf.len())
+        };
+        if n < 0 {
+            let errmsg = unsafe { librpm_sys::rpmfileStrerror(n as i32) };
+            let msg = if errmsg.is_null() {
+                "archive read error".to_string()
+            } else {
+                let s = unsafe { CStr::from_ptr(errmsg) }
+                    .to_string_lossy()
+                    .into_owned();
+                unsafe { free(errmsg.cast()) };
+                s
+            };
+            Err(io::Error::other(msg))
+        } else {
+            Ok(n as usize)
+        }
+    }
+}

--- a/src/db.rs
+++ b/src/db.rs
@@ -47,7 +47,7 @@ use crate::internal::iterator::{MatchIterator, MireMode};
 use crate::internal::rpmdb_lock;
 use crate::internal::tag::DBIndexTag;
 use crate::internal::ts::TransactionSet;
-use crate::package::Package;
+use crate::package::PackageHeader;
 use streaming_iterator::StreamingIterator;
 
 /// Handle to the RPM database.
@@ -210,10 +210,10 @@ impl Iter {
 }
 
 impl Iterator for Iter {
-    type Item = Package;
+    type Item = PackageHeader;
 
-    fn next(&mut self) -> Option<Package> {
-        self.0.next().map(Package::from_header)
+    fn next(&mut self) -> Option<PackageHeader> {
+        self.0.next().map(PackageHeader::from_header)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -75,6 +75,8 @@ pub enum ErrorKind {
     FormatString,
     /// Database operation failed
     Database,
+    /// Archive (payload) read/extraction error
+    Archive,
 }
 
 impl Display for ErrorKind {
@@ -85,6 +87,7 @@ impl Display for ErrorKind {
             ErrorKind::Macro => write!(f, "macro expansion error"),
             ErrorKind::FormatString => write!(f, "format string error"),
             ErrorKind::Database => write!(f, "database error"),
+            ErrorKind::Archive => write!(f, "archive error"),
         }
     }
 }

--- a/src/files.rs
+++ b/src/files.rs
@@ -46,6 +46,13 @@ unsafe impl Send for Files {}
 unsafe impl Sync for Files {}
 
 impl Files {
+    pub(crate) fn as_ptr(&self) -> *mut librpm_sys::rpmfiles_s {
+        match self.ptr {
+            Some(ptr) => ptr.as_ptr(),
+            None => std::ptr::null_mut(),
+        }
+    }
+
     pub(crate) fn from_header(header: &Header) -> Self {
         let ptr = unsafe {
             librpm_sys::rpmfilesNew(
@@ -270,6 +277,10 @@ impl ExactSizeIterator for FileIter<'_> {}
 pub struct FileAttrs(u32);
 
 impl FileAttrs {
+    pub(crate) fn from_raw(raw: u32) -> Self {
+        FileAttrs(raw)
+    }
+
     /// Raw flag bits.
     pub fn bits(self) -> u32 {
         self.0

--- a/src/internal/header.rs
+++ b/src/internal/header.rs
@@ -53,6 +53,16 @@ impl Header {
     }
 
     pub(crate) fn from_file(path: &Path) -> Result<Self, RpmErrorKind> {
+        let (header, fd) = Self::read_package_file(path)?;
+        unsafe { librpm_sys::Fclose(fd) };
+        Ok(header)
+    }
+
+    /// Open an RPM file, read its header, and return both the header and the
+    /// still-open file descriptor. After `rpmReadPackageFile`, the fd is
+    /// positioned at the start of the payload — callers that need to read the
+    /// archive content should keep it open.
+    pub(crate) fn read_package_file(path: &Path) -> Result<(Self, librpm_sys::FD_t), RpmErrorKind> {
         let txn = TransactionSet::create();
 
         let filename = CString::new(path.as_os_str().as_bytes()).unwrap();
@@ -60,6 +70,10 @@ impl Header {
 
         // Safety: filename and fmode are valid CStrings kept alive for the call
         let fd: librpm_sys::FD_t = unsafe { librpm_sys::Fopen(filename.as_ptr(), fmode.as_ptr()) };
+
+        if fd.is_null() {
+            return Err(RpmErrorKind::Fail);
+        }
 
         #[allow(unused_mut)]
         let mut vsflags = librpm_sys::rpmVSFlags_e_RPMVSF_NOHDRCHK
@@ -95,14 +109,13 @@ impl Header {
         // Safety: rpmReadPackageFile takes a `Header *hdrp` out-parameter.
         // It sets `*hdrp = NULL`, then on success sets `*hdrp = headerLink(h)`.
         // We pass a null pointer — not a headerNew() result — to avoid leaking
-        // the overwritten header. Fclose is called on all paths.
+        // the overwritten header. On error, Fclose is called before returning.
         unsafe {
             let raw_ts = txn.as_ptr();
             librpm_sys::rpmtsSetVSFlags(raw_ts, vsflags);
 
             let mut hdr_ptr: librpm_sys::Header = std::ptr::null_mut();
             let rc = librpm_sys::rpmReadPackageFile(raw_ts, fd, std::ptr::null(), &mut hdr_ptr);
-            librpm_sys::Fclose(fd);
 
             match RpmReturnCode::from_raw(rc) {
                 Some(RpmReturnCode::Ok) => {
@@ -110,12 +123,17 @@ impl Header {
                     // rpmReadPackageFile already called headerLink; the header
                     // has refcount 1. Wrap it directly — do NOT call headerLink
                     // again (Header::from_ptr would double-link).
-                    Ok(Header(hdr_ptr))
+                    Ok((Header(hdr_ptr), fd))
                 }
-                Some(RpmReturnCode::NotFound) => Err(RpmErrorKind::NotFound),
-                Some(RpmReturnCode::NotTrusted) => Err(RpmErrorKind::NotTrusted),
-                Some(RpmReturnCode::NoKey) => Err(RpmErrorKind::NoKey),
-                _ => Err(RpmErrorKind::Fail),
+                err => {
+                    librpm_sys::Fclose(fd);
+                    match err {
+                        Some(RpmReturnCode::NotFound) => Err(RpmErrorKind::NotFound),
+                        Some(RpmReturnCode::NotTrusted) => Err(RpmErrorKind::NotTrusted),
+                        Some(RpmReturnCode::NoKey) => Err(RpmErrorKind::NoKey),
+                        _ => Err(RpmErrorKind::Fail),
+                    }
+                }
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,9 @@ use std::path::Path;
 #[macro_use]
 pub mod error;
 
+/// Archive (payload) extraction for RPM packages
+pub mod archive;
+
 /// RPM configuration (i.e. rpmrc)
 mod config;
 
@@ -79,10 +82,10 @@ pub mod version;
 pub mod sign;
 
 pub use self::{
-    changelog::ChangelogEntry, db::Db, db::Index, db::MatchMode, dep::DepFlags, dep::Dependencies,
-    dep::Dependency, error::Error, files::FileAttrs, files::FileEntry, files::Files,
-    logging::LogBehavior, logging::LogLevel, macro_context::MacroContext, package::Package,
-    version::Version,
+    archive::ArchiveEntry, archive::PackageReader, changelog::ChangelogEntry, db::Db, db::Index,
+    db::MatchMode, dep::DepFlags, dep::Dependencies, dep::Dependency, error::Error,
+    files::FileAttrs, files::FileEntry, files::Files, logging::LogBehavior, logging::LogLevel,
+    macro_context::MacroContext, package::PackageHeader, version::Version,
 };
 
 // Re-export types used in public API

--- a/src/package.rs
+++ b/src/package.rs
@@ -45,19 +45,19 @@ use std::{fmt, path::Path, time};
 /// These point directly into the header's in-memory blob (via
 /// `HEADERGET_MINMEM`), so they are valid as long as the `Package`
 /// is alive. No allocation or copy occurs.
-pub struct Package {
+pub struct PackageHeader {
     header: Header,
 }
 
-impl Package {
+impl PackageHeader {
     pub(crate) fn from_header(h: &Header) -> Self {
-        Package { header: h.clone() }
+        PackageHeader { header: h.clone() }
     }
 
     /// Create a Package by reading an `.rpm` file
     pub fn from_file(path: &Path) -> Result<Self, RpmErrorKind> {
         let header = Header::from_file(path)?;
-        Ok(Package { header })
+        Ok(PackageHeader { header })
     }
 
     /// Look up raw tag data from the underlying RPM header
@@ -210,10 +210,10 @@ impl Package {
     /// otherwise invalid.
     ///
     /// ```no_run
-    /// use librpm::Package;
+    /// use librpm::PackageHeader;
     /// use std::path::Path;
     ///
-    /// let pkg = Package::from_file(Path::new("bash-5.2.15-3.fc39.x86_64.rpm")).unwrap();
+    /// let pkg = PackageHeader::from_file(Path::new("bash-5.2.15-3.fc39.x86_64.rpm")).unwrap();
     /// let nvra = pkg.format("%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}").unwrap();
     /// println!("{nvra}");
     /// ```
@@ -234,17 +234,17 @@ impl Package {
     }
 }
 
-impl Clone for Package {
+impl Clone for PackageHeader {
     fn clone(&self) -> Self {
-        Package {
+        PackageHeader {
             header: self.header.clone(),
         }
     }
 }
 
-impl fmt::Debug for Package {
+impl fmt::Debug for PackageHeader {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Package")
+        f.debug_struct("PackageHeader")
             .field("name", &self.name())
             .field("epoch", &self.epoch())
             .field("version", &self.version())
@@ -254,13 +254,13 @@ impl fmt::Debug for Package {
     }
 }
 
-impl fmt::Display for Package {
+impl fmt::Display for PackageHeader {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.nevra())
     }
 }
 
-impl PartialEq for Package {
+impl PartialEq for PackageHeader {
     fn eq(&self, other: &Self) -> bool {
         self.name() == other.name()
             && self.epoch() == other.epoch()
@@ -270,9 +270,9 @@ impl PartialEq for Package {
     }
 }
 
-impl Eq for Package {}
+impl Eq for PackageHeader {}
 
-impl Hash for Package {
+impl Hash for PackageHeader {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.name().hash(state);
         self.epoch().hash(state);

--- a/tests/archive.rs
+++ b/tests/archive.rs
@@ -1,0 +1,181 @@
+//! Tests for archive (payload) extraction.
+
+use std::io::Read;
+use std::path::Path;
+
+use librpm::PackageHeader;
+use librpm::archive::PackageReader;
+
+mod common;
+
+fn assets_path() -> std::path::PathBuf {
+    common::get_assets_path().join("rpms")
+}
+
+fn basic_rpm() -> std::path::PathBuf {
+    assets_path().join("rpm-basic-with-rsa4096-2.3.4-5.el9.noarch.rpm")
+}
+
+fn empty_rpm() -> std::path::PathBuf {
+    assets_path().join("rpm-empty-0-0.x86_64.rpm")
+}
+
+#[test]
+fn test_archive_entry_count() {
+    common::configure();
+
+    let pkg = PackageHeader::from_file(&basic_rpm()).unwrap();
+    let non_ghost_files = pkg.files().iter().filter(|f| !f.flags().is_ghost()).count();
+
+    let mut archive = PackageReader::open(&basic_rpm()).unwrap();
+    let mut count = 0;
+    while let Some(_entry) = archive.next_entry().unwrap() {
+        count += 1;
+    }
+
+    assert_eq!(
+        count, non_ghost_files,
+        "archive entry count should match the number of non-ghost files"
+    );
+}
+
+#[test]
+fn test_archive_entry_metadata() {
+    common::configure();
+
+    let mut archive = PackageReader::open(&basic_rpm()).unwrap();
+    let mut paths = Vec::new();
+
+    while let Some(entry) = archive.next_entry().unwrap() {
+        paths.push(entry.path());
+    }
+
+    assert!(paths.contains(&"/etc/rpm-basic/example_config.toml".to_string()));
+    assert!(paths.contains(&"/usr/bin/rpm-basic".to_string()));
+    assert!(paths.contains(&"/usr/share/doc/rpm-basic/README".to_string()));
+}
+
+#[test]
+fn test_archive_entry_detailed_metadata() {
+    common::configure();
+
+    let mut archive = PackageReader::open(&basic_rpm()).unwrap();
+
+    while let Some(entry) = archive.next_entry().unwrap() {
+        if entry.path() == "/etc/rpm-basic/example_config.toml" {
+            assert_eq!(entry.size(), 31);
+            assert_eq!(entry.user(), "root");
+            assert_eq!(entry.group(), "root");
+            assert!(entry.flags().is_config());
+            assert_eq!(entry.basename(), "example_config.toml");
+            assert_eq!(entry.dirname(), "/etc/rpm-basic/");
+            return;
+        }
+    }
+    panic!("config file not found in archive");
+}
+
+#[test]
+fn test_archive_read_content() {
+    common::configure();
+
+    let mut archive = PackageReader::open(&basic_rpm()).unwrap();
+
+    while let Some(mut entry) = archive.next_entry().unwrap() {
+        if entry.has_content() && entry.size() > 0 {
+            let mut buf = Vec::new();
+            let n = entry.read_to_end(&mut buf).unwrap();
+            assert_eq!(
+                n as u64,
+                entry.size(),
+                "read byte count should match size for {}",
+                entry.path()
+            );
+            assert!(!buf.is_empty());
+            return;
+        }
+    }
+    panic!("no entry with readable content found");
+}
+
+#[test]
+fn test_archive_read_specific_file() {
+    common::configure();
+
+    let mut archive = PackageReader::open(&basic_rpm()).unwrap();
+
+    while let Some(mut entry) = archive.next_entry().unwrap() {
+        if entry.path() == "/etc/rpm-basic/example_config.toml" {
+            assert!(entry.has_content());
+            let mut buf = Vec::new();
+            entry.read_to_end(&mut buf).unwrap();
+            assert_eq!(buf.len(), 31);
+            let content = String::from_utf8(buf).unwrap();
+            assert!(!content.is_empty());
+            return;
+        }
+    }
+    panic!("config file not found in archive");
+}
+
+#[test]
+fn test_archive_package_metadata() {
+    common::configure();
+
+    let archive = PackageReader::open(&basic_rpm()).unwrap();
+    let pkg = archive.package();
+
+    assert_eq!(pkg.name(), "rpm-basic");
+    assert_eq!(pkg.version(), "2.3.4");
+    assert_eq!(pkg.release(), "5.el9");
+    assert_eq!(pkg.nevra(), "rpm-basic-1:2.3.4-5.el9.noarch");
+}
+
+#[test]
+fn test_archive_empty_package() {
+    common::configure();
+
+    let mut archive = PackageReader::open(&empty_rpm()).unwrap();
+    let mut count = 0;
+    while let Some(_entry) = archive.next_entry().unwrap() {
+        count += 1;
+    }
+    assert_eq!(count, 0, "empty package should have no archive entries");
+}
+
+#[test]
+fn test_archive_exhausted_returns_none() {
+    common::configure();
+
+    let mut archive = PackageReader::open(&basic_rpm()).unwrap();
+
+    while archive.next_entry().unwrap().is_some() {}
+
+    assert!(
+        archive.next_entry().unwrap().is_none(),
+        "next_entry should keep returning None after exhaustion"
+    );
+}
+
+#[test]
+fn test_archive_nonexistent_file() {
+    common::configure();
+
+    let result = PackageReader::open(Path::new("/nonexistent/path/to/package.rpm"));
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_archive_does_not_contain_ghost_files() {
+    common::configure();
+
+    let mut archive = PackageReader::open(&basic_rpm()).unwrap();
+
+    while let Some(entry) = archive.next_entry().unwrap() {
+        assert!(
+            !entry.flags().is_ghost(),
+            "ghost files should not appear in the archive: {}",
+            entry.path(),
+        );
+    }
+}

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -13,7 +13,7 @@ use std::{
 use std::time;
 
 use librpm::db::MatchMode;
-use librpm::{Db, Index, Package};
+use librpm::{Db, Index, PackageHeader};
 
 static INIT: OnceLock<()> = OnceLock::new();
 static DISTRO: OnceLock<&'static str> = OnceLock::new();
@@ -62,7 +62,7 @@ pub struct SamplePackage {
 pub fn assert_distro(distro: &DistroTestCase) {
     let db = init(distro);
 
-    let mut packages: Vec<Package> = db.installed_packages().collect();
+    let mut packages: Vec<PackageHeader> = db.installed_packages().collect();
     packages.sort_by_key(|p| p.name().to_string());
 
     assert_eq!(
@@ -87,7 +87,7 @@ pub fn assert_distro(distro: &DistroTestCase) {
 pub fn assert_find_by_name(distro: &DistroTestCase) {
     let db = init(distro);
 
-    let results: Vec<Package> = db.find(Index::Name, distro.sample.name).collect();
+    let results: Vec<PackageHeader> = db.find(Index::Name, distro.sample.name).collect();
     assert_eq!(
         results.len(),
         1,
@@ -107,7 +107,7 @@ pub fn assert_find_by_name(distro: &DistroTestCase) {
 pub fn assert_find_nonexistent(distro: &DistroTestCase) {
     let db = init(distro);
 
-    let results: Vec<Package> = db.find(Index::Name, "nonexistent-package-xyz").collect();
+    let results: Vec<PackageHeader> = db.find(Index::Name, "nonexistent-package-xyz").collect();
     assert_eq!(
         results.len(),
         0,
@@ -119,7 +119,7 @@ pub fn assert_find_nonexistent(distro: &DistroTestCase) {
 pub fn assert_find_by_providename(distro: &DistroTestCase) {
     let db = init(distro);
 
-    let results: Vec<Package> = db.find(Index::Providename, distro.sample.name).collect();
+    let results: Vec<PackageHeader> = db.find(Index::Providename, distro.sample.name).collect();
     assert!(
         results.iter().any(|p| p.name() == distro.sample.name),
         "{}: '{}' should provide itself",
@@ -131,7 +131,7 @@ pub fn assert_find_by_providename(distro: &DistroTestCase) {
 pub fn assert_find_by_requirename(distro: &DistroTestCase) {
     let db = init(distro);
 
-    let results: Vec<Package> = db.find(Index::Requirename, "glibc").collect();
+    let results: Vec<PackageHeader> = db.find(Index::Requirename, "glibc").collect();
     assert!(
         !results.is_empty(),
         "{}: at least one package should require glibc",
@@ -142,7 +142,7 @@ pub fn assert_find_by_requirename(distro: &DistroTestCase) {
 pub fn assert_find_by_dirnames(distro: &DistroTestCase) {
     let db = init(distro);
 
-    let results: Vec<Package> = db.find(Index::Dirnames, "/etc/").collect();
+    let results: Vec<PackageHeader> = db.find(Index::Dirnames, "/etc/").collect();
     assert!(
         !results.is_empty(),
         "{}: at least one package should own files in /etc/",
@@ -171,7 +171,7 @@ pub fn assert_find_by_dirnames(distro: &DistroTestCase) {
 pub fn assert_find_re_glob(distro: &DistroTestCase) {
     let db = init(distro);
 
-    let results: Vec<Package> = db
+    let results: Vec<PackageHeader> = db
         .find_re(Index::Name, "alternatives*", MatchMode::Glob)
         .collect();
     assert!(
@@ -184,7 +184,7 @@ pub fn assert_find_re_glob(distro: &DistroTestCase) {
 pub fn assert_find_re_regex(distro: &DistroTestCase) {
     let db = init(distro);
 
-    let results: Vec<Package> = db
+    let results: Vec<PackageHeader> = db
         .find_re(Index::Name, "^alternatives$", MatchMode::Regex)
         .collect();
     assert_eq!(
@@ -199,7 +199,7 @@ pub fn assert_find_re_regex(distro: &DistroTestCase) {
 pub fn assert_find_re_no_match(distro: &DistroTestCase) {
     let db = init(distro);
 
-    let results: Vec<Package> = db
+    let results: Vec<PackageHeader> = db
         .find_re(Index::Name, "zzz-nonexistent*", MatchMode::Glob)
         .collect();
     assert_eq!(

--- a/tests/config_retry.rs
+++ b/tests/config_retry.rs
@@ -45,7 +45,7 @@ fn test_config_behavior() {
 
     // Db::open() should succeed after configuration
     let db = librpm::Db::open().expect("Db::open() should succeed after config");
-    let results: Vec<librpm::Package> = db
+    let results: Vec<librpm::PackageHeader> = db
         .find(librpm::Index::Name, "nonexistent-pkg-xyz")
         .collect();
     assert_eq!(results.len(), 0);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6,7 +6,7 @@
 //! and macro operations rather than index queries.
 
 use librpm::db::{Index, MatchMode};
-use librpm::{Db, Package, Tag};
+use librpm::{Db, PackageHeader, Tag};
 
 mod common;
 
@@ -14,7 +14,7 @@ mod common;
 fn test_scalar_int32_tag() {
     let db = common::init(&common::CENTOS_STREAM_9);
 
-    let results: Vec<Package> = db.find(Index::Name, "alternatives").collect();
+    let results: Vec<PackageHeader> = db.find(Index::Name, "alternatives").collect();
     let package = &results[0];
 
     let buildtime = package.get(Tag::BUILDTIME).expect("BUILDTIME should exist");
@@ -31,7 +31,7 @@ fn test_scalar_int32_tag() {
 fn test_array_tag_data() {
     let db = common::init(&common::CENTOS_STREAM_9);
 
-    let results: Vec<Package> = db.find(Index::Name, "alternatives").collect();
+    let results: Vec<PackageHeader> = db.find(Index::Name, "alternatives").collect();
     let pkg = &results[0];
 
     let basenames = pkg.get(Tag::BASENAMES).expect("BASENAMES tag missing");
@@ -65,7 +65,7 @@ fn test_array_tag_data() {
 fn test_tag_type_mismatch_returns_none() {
     let db = common::init(&common::CENTOS_STREAM_9);
 
-    let results: Vec<Package> = db.find(Index::Name, "alternatives").collect();
+    let results: Vec<PackageHeader> = db.find(Index::Name, "alternatives").collect();
     let pkg = &results[0];
 
     let name = pkg.get(Tag::NAME).expect("NAME should exist");
@@ -110,7 +110,7 @@ fn db_find_test_multiple() {
 fn find_re_glob_returns_superset() {
     let db = common::init(&common::CENTOS_STREAM_9);
 
-    let results: Vec<Package> = db.find_re(Index::Name, "glibc*", MatchMode::Glob).collect();
+    let results: Vec<PackageHeader> = db.find_re(Index::Name, "glibc*", MatchMode::Glob).collect();
     assert!(
         results.len() >= 2,
         "glob 'glibc*' should match glibc and glibc-common (got {})",
@@ -135,7 +135,7 @@ fn db_find_test_multiple_packages() {
 
 #[test]
 fn iterator_outlives_db() {
-    let packages: Vec<Package> = {
+    let packages: Vec<PackageHeader> = {
         let db = common::init(&common::CENTOS_STREAM_9);
         db.installed_packages().collect()
     };
@@ -151,7 +151,7 @@ fn iterator_outlives_db() {
 fn find_re_regex_returns_superset() {
     let db = common::init(&common::CENTOS_STREAM_9);
 
-    let results: Vec<Package> = db
+    let results: Vec<PackageHeader> = db
         .find_re(Index::Name, "^glibc", MatchMode::Regex)
         .collect();
     assert!(
@@ -177,8 +177,8 @@ fn multiple_db_instances() {
     let count2 = db2.installed_packages().count();
     assert_eq!(count1, count2);
 
-    let results1: Vec<Package> = db1.find(Index::Name, "bash").collect();
-    let results2: Vec<Package> = db2.find(Index::Name, "bash").collect();
+    let results1: Vec<PackageHeader> = db1.find(Index::Name, "bash").collect();
+    let results2: Vec<PackageHeader> = db2.find(Index::Name, "bash").collect();
     assert_eq!(results1.len(), results2.len());
     assert_eq!(results1[0].name(), results2[0].name());
 }
@@ -191,7 +191,7 @@ fn concurrent_db_instances() {
         .map(|_| {
             std::thread::spawn(|| {
                 let db = Db::open().unwrap();
-                let packages: Vec<Package> = db.installed_packages().collect();
+                let packages: Vec<PackageHeader> = db.installed_packages().collect();
                 assert!(!packages.is_empty());
                 packages.len()
             })
@@ -206,7 +206,7 @@ fn concurrent_db_instances() {
 fn find_re_glob_by_providename() {
     let db = common::init(&common::CENTOS_STREAM_9);
 
-    let results: Vec<Package> = db
+    let results: Vec<PackageHeader> = db
         .find_re(Index::Providename, "glibc*", MatchMode::Glob)
         .collect();
     assert!(

--- a/tests/package.rs
+++ b/tests/package.rs
@@ -4,7 +4,7 @@
 use std::collections::HashSet;
 use std::path::Path;
 
-use librpm::{Package, Tag, error::ErrorKind};
+use librpm::{PackageHeader, Tag, error::ErrorKind};
 
 mod common;
 
@@ -12,9 +12,9 @@ fn assets_path() -> std::path::PathBuf {
     common::get_assets_path().join("rpms")
 }
 
-fn load_basic() -> Package {
+fn load_basic() -> PackageHeader {
     common::configure();
-    Package::from_file(&assets_path().join("rpm-basic-with-rsa4096-2.3.4-5.el9.noarch.rpm"))
+    PackageHeader::from_file(&assets_path().join("rpm-basic-with-rsa4096-2.3.4-5.el9.noarch.rpm"))
         .unwrap()
 }
 
@@ -45,7 +45,7 @@ fn test_from_file_basic_metadata() {
 #[test]
 fn test_from_file_empty_package() {
     common::configure();
-    let pkg = Package::from_file(&assets_path().join("rpm-empty-0-0.x86_64.rpm")).unwrap();
+    let pkg = PackageHeader::from_file(&assets_path().join("rpm-empty-0-0.x86_64.rpm")).unwrap();
 
     assert_eq!(pkg.name(), "rpm-empty");
     assert_eq!(pkg.epoch(), None);
@@ -59,7 +59,7 @@ fn test_from_file_empty_package() {
 #[test]
 fn test_from_file_nonexistent() {
     common::configure();
-    let result = Package::from_file(Path::new("/nonexistent/path/to/package.rpm"));
+    let result = PackageHeader::from_file(Path::new("/nonexistent/path/to/package.rpm"));
     assert!(result.is_err());
 }
 
@@ -139,7 +139,7 @@ fn test_tag_missing_returns_none() {
     assert!(pkg.get(Tag::EPOCH).is_some());
 
     common::configure();
-    let empty = Package::from_file(&assets_path().join("rpm-empty-0-0.x86_64.rpm")).unwrap();
+    let empty = PackageHeader::from_file(&assets_path().join("rpm-empty-0-0.x86_64.rpm")).unwrap();
     assert!(empty.get(Tag::EPOCH).is_none());
 }
 
@@ -216,7 +216,7 @@ fn test_file_digest() {
 #[test]
 fn test_files_empty_package() {
     common::configure();
-    let pkg = Package::from_file(&assets_path().join("rpm-empty-0-0.x86_64.rpm")).unwrap();
+    let pkg = PackageHeader::from_file(&assets_path().join("rpm-empty-0-0.x86_64.rpm")).unwrap();
     let files = pkg.files();
 
     assert_eq!(files.len(), 0);
@@ -337,7 +337,7 @@ fn test_suggests() {
 #[test]
 fn test_dependencies_empty_package() {
     common::configure();
-    let pkg = Package::from_file(&assets_path().join("rpm-empty-0-0.x86_64.rpm")).unwrap();
+    let pkg = PackageHeader::from_file(&assets_path().join("rpm-empty-0-0.x86_64.rpm")).unwrap();
 
     assert!(pkg.requires().iter().all(|d| d.flags().is_rpmlib()));
     assert!(pkg.provides().len() >= 1); // self-provide always exists
@@ -387,7 +387,7 @@ fn test_format_nevra() {
 #[test]
 fn test_format_epoch_missing_display() {
     common::configure();
-    let pkg = Package::from_file(&assets_path().join("rpm-empty-0-0.x86_64.rpm")).unwrap();
+    let pkg = PackageHeader::from_file(&assets_path().join("rpm-empty-0-0.x86_64.rpm")).unwrap();
     // librpm renders a missing EPOCH as "(none)" in the format string
     let result = pkg.format("%{EPOCH}").unwrap();
     assert_eq!(result, "(none)");
@@ -442,7 +442,7 @@ fn test_package_partial_eq() {
     assert_eq!(pkg1, pkg2);
 
     common::configure();
-    let empty = Package::from_file(&assets_path().join("rpm-empty-0-0.x86_64.rpm")).unwrap();
+    let empty = PackageHeader::from_file(&assets_path().join("rpm-empty-0-0.x86_64.rpm")).unwrap();
     assert_ne!(pkg1, empty);
 }
 

--- a/tests/test-current-system.rs
+++ b/tests/test-current-system.rs
@@ -25,7 +25,7 @@
 
 #![cfg(feature = "test-current-system")]
 
-use librpm::Package;
+use librpm::PackageHeader;
 use librpm::db::Index;
 use std::process::Command;
 
@@ -111,7 +111,7 @@ fn test_against_installed_packages() {
 fn db_find_test_multiple_matching() {
     let db = common::configure();
 
-    let matches: Vec<librpm::Package> = db.find(Index::Name, "kernel").collect();
+    let matches: Vec<librpm::PackageHeader> = db.find(Index::Name, "kernel").collect();
     assert!(matches.len() > 1);
 
     for package in matches {


### PR DESCRIPTION
Wraps librpm's rpmarchive.h to provide sequential, streaming access to the file contents inside .rpm packages. PackageReaer::open() reads the header and positions the fd at the payload; next_entry() yields ArchiveEntry values that implement std::io::Read for streaming content.

Since the Package struct is now a bit misleading, rename it to PackageHeader.

Assisted-By: Claude Opus 4.6